### PR TITLE
Correctly reshape decompressed array data from [] notation.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,6 @@ jobs:
             && conda create --yes -n test python==${{ matrix.python }} \
             && conda activate test \
             && conda install --yes --file packaging/conda_build_requirements.txt
-        run: |
           if test ${{ matrix.python }} = "3.9"; then conda install libxcrypt; fi
 
       - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,8 @@ jobs:
             && conda create --yes -n test python==${{ matrix.python }} \
             && conda activate test \
             && conda install --yes --file packaging/conda_build_requirements.txt
+        run: |
+          if test ${{ matrix.python }} = "3.9"; then conda install libxcrypt; fi
 
       - name: Install
         run: |

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -41,7 +41,7 @@ create an environment called "flacarray". First create the env with all
 dependencies and activate it (FIXME, add a requirements file for dev):
 
     conda create -n flacarray \
-        c_compiler numpy libflac cython meson-python pkgconfig
+        c-compiler numpy libflac cython meson-python pkgconfig
 
     conda activate flacarray
 

--- a/src/flacarray/array.py
+++ b/src/flacarray/array.py
@@ -284,13 +284,15 @@ class FlacArray:
                             raise ValueError(msg)
                         first = axkey.start
                         last = axkey.stop
-                        istart = first
-                        if istart is None:
-                            istart = 0
-                        istop = last
-                        if istop is None:
-                            istop = self._shape[-1]
-                        sample_shape = (istop - istart,)
+                        if first is None or first < 0:
+                            first = 0
+                        if first > self._shape[-1] - 1:
+                            first = self._shape[-1] - 1
+                        if last is None or last > self._shape[-1]:
+                            last = self._shape[-1]
+                        if last < 1:
+                            last = 1
+                        sample_shape = (last - first,)
                     elif isinstance(axkey, (int, np.integer)):
                         # Just a scalar
                         first = axkey

--- a/src/flacarray/array.py
+++ b/src/flacarray/array.py
@@ -278,7 +278,7 @@ class FlacArray:
             vw[0] = key
             keep = self._keep_view(tuple(vw))
 
-        arr, _ = array_decompress_slice(
+        arr, strm_indices = array_decompress_slice(
             self._compressed,
             self._stream_size,
             self._stream_starts,
@@ -289,7 +289,15 @@ class FlacArray:
             first_stream_sample=first,
             last_stream_sample=last,
         )
-        return arr
+        arr_indices = np.transpose(np.array(strm_indices))
+        leading = [
+            len(np.unique(arr_indices[x])) for x in range(len(self._leading_shape))
+        ]
+        if first is None:
+            full_shape = tuple(leading) + (self._shape[-1],)
+        else:
+            full_shape = tuple(leading) + (last - first,)
+        return np.squeeze(arr.reshape(full_shape))
 
     def __delitem__(self, key):
         raise RuntimeError("Cannot delete individual streams")

--- a/src/flacarray/tests/array.py
+++ b/src/flacarray/tests/array.py
@@ -193,6 +193,9 @@ class ArrayTest(unittest.TestCase):
             (2, slice(0, 1, 1), slice(0, 1, 1), slice(None)),
             (1, slice(1, 3, 1), slice(6, 8, 1), 50),
             (slice(1, 3, 1), 2, slice(6, 8, 1), slice(60, 80, 1)),
+            (2, 1, slice(2, 8, 2), slice(80, 120, 1)),
+            (2, 1, slice(2, 8, 2), slice(80, None)),
+            (2, 1, slice(2, 8, 2), slice(None, 10)),
         ]:
             # Slice of the original numpy array
             check = data_i32[dslc]

--- a/src/flacarray/tests/array.py
+++ b/src/flacarray/tests/array.py
@@ -188,6 +188,10 @@ class ArrayTest(unittest.TestCase):
 
         # Try some slices and verify expected result shape.
         for dslc in [
+            (slice(0)),
+            (slice(1, 3)),
+            (slice(3, 1)),
+            (slice(3, 1, -1)),
             (1, 2, 5, 50),
             (1, 2, 5),
             (2, slice(0, 1, 1), slice(0, 1, 1), slice(None)),

--- a/src/flacarray/tests/array.py
+++ b/src/flacarray/tests/array.py
@@ -187,16 +187,22 @@ class ArrayTest(unittest.TestCase):
         farray = FlacArray.from_array(data_i32)
 
         # Try some slices and verify expected result shape.
-        for dslc, dshape in [
-            ((1, 2, 5, 50), ()),
-            ((1, 2, 5), (100,)),
-            ((1, slice(1, 3, 1), slice(6, 8, 1), 50), (2, 2)),
-            ((slice(1, 3, 1), 2, slice(6, 8, 1), slice(60, 80, 1)), (2, 2, 20)),
+        for dslc in [
+            (1, 2, 5, 50),
+            (1, 2, 5),
+            (2, slice(0, 1, 1), slice(0, 1, 1), slice(None)),
+            (1, slice(1, 3, 1), slice(6, 8, 1), 50),
+            (slice(1, 3, 1), 2, slice(6, 8, 1), slice(60, 80, 1)),
         ]:
-            check = farray[dslc]
-            if check.shape != dshape:
+            # Slice of the original numpy array
+            check = data_i32[dslc]
+            # Slice of the FlacArray
+            fcheck = farray[dslc]
+
+            # Compare the shapes
+            if fcheck.shape != check.shape:
                 print(
-                    f"Array[{dslc}] shape: {check.shape} != {dshape}",
+                    f"Array[{dslc}] shape: {fcheck.shape} != {check.shape}",
                     flush=True,
                 )
                 raise RuntimeError("Failed slice shape check")


### PR DESCRIPTION
Also add a unit test for returned shape.  Closes #5.