### PR TITLE
Add support for FLAC compression of 64bit integers.

### DIFF
--- a/src/flacarray/array.py
+++ b/src/flacarray/array.py
@@ -29,7 +29,7 @@ class FlacArray:
     stream in the overall bytes array.  The shape of the starting array corresponds
     to the shape of the leading, un-compressed dimensions of the original array.
 
-    The input data is converted to 32bit integers.  The "quanta" value is used
+    The input data is converted to 32bit or 64bit integers.  The "quanta" value is used
     for floating point data conversion and represents the floating point increment
     for a single integer value.  If quanta is None, each stream is scaled independently
     based on its data range.  If quanta is a scalar, all streams are scaled with the
@@ -42,20 +42,19 @@ class FlacArray:
     The following rules specify the data conversion that is performed depending on
     the input type:
 
-    * int32:  No conversion.
+    * int32:  No conversion.  Compressed to single channel FLAC bytestream.
 
-    * int64:  Subtract the integer closest to the mean, then truncate to lower
-        32 bits, and check that the higher bits were zero.
+    * int64:  No conversion.  Compressed to 2-channel (stereo) FLAC bytestream.
 
     * float32:  Subtract the mean and scale data based on the quanta value (see
         above).  Then round to nearest 32bit integer.
 
     * float64:  Subtract the mean and scale data based on the quanta value (see
-        above).  Then round to nearest 32bit integer.
+        above).  Then round to nearest 64bit integer.
 
-    After conversion to 32bit integers, each stream's data is separately compressed
-    into a sequence of FLAC bytes, which is appended to the bytestream.  The offset in
-    bytes for each stream is recorded.
+    After conversion to integers, each stream's data is separately compressed into a
+    sequence of FLAC bytes, which is appended to the bytestream.  The offset in bytes
+    for each stream is recorded.
 
     A FlacArray is only constructed directly when making a copy.  Use the class methods
     to create FlacArrays from numpy arrays or on-disk representations.
@@ -71,6 +70,7 @@ class FlacArray:
         shape=None,
         global_shape=None,
         compressed=None,
+        is_int64=None,
         stream_starts=None,
         stream_nbytes=None,
         stream_offsets=None,
@@ -84,6 +84,7 @@ class FlacArray:
             self._shape = copy.deepcopy(other._shape)
             self._global_shape = copy.deepcopy(other._global_shape)
             self._compressed = copy.deepcopy(other._compressed)
+            self._is_int64 = other._is_int64
             self._stream_starts = copy.deepcopy(other._stream_starts)
             self._stream_nbytes = copy.deepcopy(other._stream_nbytes)
             self._stream_offsets = copy.deepcopy(other._stream_offsets)
@@ -97,6 +98,7 @@ class FlacArray:
             self._shape = shape
             self._global_shape = global_shape
             self._compressed = compressed
+            self._is_int64 = is_int64
             self._stream_starts = stream_starts
             self._stream_nbytes = stream_nbytes
             self._stream_offsets = stream_offsets
@@ -124,17 +126,24 @@ class FlacArray:
         if self._stream_offsets is not None:
             if self._stream_gains is not None:
                 # This is floating point data
-                if self._stream_gains.dtype == np.dtype(np.float64):
+                if self._is_int64:
                     self._typestr = "float64"
                 else:
                     self._typestr = "float32"
             else:
-                # This is int64 data
-                self._typestr = "int64"
+                raise RuntimeError("Offsets and gains must both be None or not None")
         else:
-            self._typestr = "int32"
+            if self._is_int64:
+                self._typestr = "int64"
+            else:
+                self._typestr = "int32"
 
     # Shapes of decompressed array
+
+    @property
+    def typestr(self):
+        """A string representation of the original data type."""
+        return self._typestr
 
     @property
     def shape(self):
@@ -288,6 +297,7 @@ class FlacArray:
             keep=keep,
             first_stream_sample=first,
             last_stream_sample=last,
+            is_int64=self._is_int64,
         )
         return arr
 
@@ -312,6 +322,9 @@ class FlacArray:
     def __eq__(self, other):
         if self._shape != other._shape:
             log.debug(f"other shape {other._shape} != {self._shape}")
+            return False
+        if self._typestr != other._typestr:
+            log.debug(f"other typestr {other._typestr} != {self._typestr}")
             return False
         if self._global_shape != other._global_shape:
             msg = f"other global_shape {other._global_shape} != {self._global_shape}"
@@ -411,6 +424,7 @@ class FlacArray:
             first_stream_sample=first_samp,
             last_stream_sample=last_samp,
             use_threads=use_threads,
+            is_int64=self._is_int64,
         )
         if keep is not None and keep_indices:
             return (arr, indices)
@@ -447,6 +461,11 @@ class FlacArray:
         global_shape = global_props["shape"]
         mpi_dist = global_props["dist"]
 
+        if arr.dtype == np.dtype(np.int64) or arr.dtype == np.dtype(np.float64):
+            is_int64 = True
+        else:
+            is_int64 = False
+
         # Compress our local piece of the array
         compressed, starts, nbytes, offsets, gains = array_compress(
             arr,
@@ -461,6 +480,7 @@ class FlacArray:
             shape=arr.shape,
             global_shape=global_shape,
             compressed=compressed,
+            is_int64=is_int64,
             stream_starts=starts,
             stream_nbytes=nbytes,
             stream_offsets=offsets,
@@ -489,6 +509,10 @@ class FlacArray:
             None
 
         """
+        if self._is_int64:
+            n_channels = 2
+        else:
+            n_channels = 1
         hdf5_write_compressed(
             hgrp,
             self._leading_shape,
@@ -500,6 +524,7 @@ class FlacArray:
             self._stream_offsets,
             self._stream_gains,
             self._compressed,
+            n_channels,
             self._compressed.nbytes,
             self._global_nbytes,
             self._global_proc_nbytes,
@@ -551,6 +576,7 @@ class FlacArray:
             local_shape,
             global_shape,
             compressed,
+            n_channels,
             stream_starts,
             stream_nbytes,
             stream_offsets,
@@ -569,6 +595,7 @@ class FlacArray:
             shape=local_shape,
             global_shape=global_shape,
             compressed=compressed,
+            is_int64=(n_channels == 2),
             stream_starts=stream_starts,
             stream_nbytes=stream_nbytes,
             stream_offsets=stream_offsets,
@@ -593,6 +620,10 @@ class FlacArray:
             None
 
         """
+        if self._is_int64:
+            n_channels = 2
+        else:
+            n_channels = 1
         zarr_write_compressed(
             zgrp,
             self._leading_shape,
@@ -604,6 +635,7 @@ class FlacArray:
             self._stream_offsets,
             self._stream_gains,
             self._compressed,
+            n_channels,
             self._compressed.nbytes,
             self._global_nbytes,
             self._global_proc_nbytes,
@@ -653,6 +685,7 @@ class FlacArray:
             local_shape,
             global_shape,
             compressed,
+            n_channels,
             stream_starts,
             stream_nbytes,
             stream_offsets,
@@ -671,6 +704,7 @@ class FlacArray:
             shape=local_shape,
             global_shape=global_shape,
             compressed=compressed,
+            is_int64=(n_channels == 2),
             stream_starts=stream_starts,
             stream_nbytes=stream_nbytes,
             stream_offsets=stream_offsets,

--- a/src/flacarray/compress.py
+++ b/src/flacarray/compress.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from .libflacarray import encode_flac
-from .utils import int64_to_int32, float_to_int32, function_timer
+from .utils import float_to_int, function_timer
 
 
 @function_timer
@@ -13,9 +13,10 @@ def array_compress(arr, level=5, quanta=None, precision=None, use_threads=False)
     """Compress a numpy array with optional floating point conversion.
 
     If `arr` is an int32 array, the returned stream offsets and gains will be None.
-    if `arr` is an int64 array, the stream offsets will be the integer value subtracted
-    when converting to int32.  Both float32 and float64 data will have floating point
-    offset and gain arrays returned.
+    if `arr` is an int64 array, the returned stream offsets and gains will be None and
+    the calling code is responsible for tracking that the compressed bytes are
+    associated with a 64bit stream.  Both float32 and float64 data will have floating
+    point offset and gain arrays returned.
 
     Args:
         arr (numpy.ndarray):  The input array data.
@@ -55,17 +56,11 @@ def array_compress(arr, level=5, quanta=None, precision=None, use_threads=False)
     else:
         dquanta = None
 
-    if arr.dtype == np.dtype(np.int32):
+    if arr.dtype == np.dtype(np.int32) or arr.dtype == np.dtype(np.int64):
         (compressed, starts, nbytes) = encode_flac(arr, level, use_threads=use_threads)
         return (compressed, starts, nbytes, None, None)
-    elif arr.dtype == np.dtype(np.int64):
-        idata, ioff = int64_to_int32(arr)
-        (compressed, starts, nbytes) = encode_flac(
-            idata, level, use_threads=use_threads
-        )
-        return (compressed, starts, nbytes, ioff, None)
-    elif arr.dtype == np.dtype(np.float64) or arr.dtype == np.dtype(np.float32):
-        idata, foff, gains = float_to_int32(arr, quanta=dquanta, precision=precision)
+    elif arr.dtype == np.dtype(np.float32) or arr.dtype == np.dtype(np.float64):
+        idata, foff, gains = float_to_int(arr, quanta=dquanta, precision=precision)
         (compressed, starts, nbytes) = encode_flac(
             idata, level, use_threads=use_threads
         )

--- a/src/flacarray/decompress.py
+++ b/src/flacarray/decompress.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from .libflacarray import decode_flac
-from .utils import int32_to_float, keep_select, function_timer, select_keep_indices
+from .utils import int_to_float, keep_select, function_timer, select_keep_indices
 
 
 @function_timer
@@ -19,6 +19,7 @@ def array_decompress_slice(
     keep=None,
     first_stream_sample=None,
     last_stream_sample=None,
+    is_int64=False,
     use_threads=False,
 ):
     """Decompress a slice of a FLAC encoded array and restore original data type.
@@ -52,6 +53,7 @@ def array_decompress_slice(
         keep (array):  Bool array of streams to keep in the decompression.
         first_stream_sample (int):  The first sample of every stream to decompress.
         last_stream_sample (int):  The last sample of every stream to decompress.
+        is_int64 (bool):  If True, the compressed stream contains 64bit integers.
         use_threads (bool):  If True, use OpenMP threads to parallelize decoding.
             This is only beneficial for large arrays.
 
@@ -79,27 +81,19 @@ def array_decompress_slice(
                 first_sample=first_stream_sample,
                 last_sample=last_stream_sample,
                 use_threads=use_threads,
+                is_int64=is_int64,
             )
-            arr = int32_to_float(idata, offsets, gains)
+            arr = int_to_float(idata, offsets, gains)
         else:
-            # This is int64 data
-            idata = decode_flac(
-                compressed,
-                starts,
-                nbytes,
-                stream_size,
-                first_sample=first_stream_sample,
-                last_sample=last_stream_sample,
-                use_threads=use_threads,
+            raise RuntimeError(
+                "When specifying offsets, you must also provide the gains"
             )
-            ext_shape = offsets.shape + (1,)
-            arr = idata.astype(np.int64) + offsets.reshape(ext_shape)
     else:
         if stream_gains is not None:
             raise RuntimeError(
                 "When specifying gains, you must also provide the offsets"
             )
-        # This is int32 data
+        # This is integer data
         arr = decode_flac(
             compressed,
             starts,
@@ -108,6 +102,7 @@ def array_decompress_slice(
             first_sample=first_stream_sample,
             last_sample=last_stream_sample,
             use_threads=use_threads,
+            is_int64=is_int64,
         )
     return (arr, indices)
 
@@ -122,6 +117,7 @@ def array_decompress(
     stream_gains=None,
     first_stream_sample=None,
     last_stream_sample=None,
+    is_int64=False,
     use_threads=False,
 ):
     """Decompress a FLAC encoded array and restore original data type.
@@ -144,6 +140,7 @@ def array_decompress(
         stream_gains (array):  The array of gains, one per stream.
         first_stream_sample (int):  The first sample of every stream to decompress.
         last_stream_sample (int):  The last sample of every stream to decompress.
+        is_int64 (bool):  If True, the compressed stream contains 64bit integers.
         use_threads (bool):  If True, use OpenMP threads to parallelize decoding.
             This is only beneficial for large arrays.
 
@@ -161,6 +158,7 @@ def array_decompress(
         keep=None,
         first_stream_sample=first_stream_sample,
         last_stream_sample=last_stream_sample,
+        is_int64=is_int64,
         use_threads=use_threads,
     )
     return arr

--- a/src/flacarray/hdf5.py
+++ b/src/flacarray/hdf5.py
@@ -112,6 +112,7 @@ def write_compressed(
     stream_offsets,
     stream_gains,
     compressed,
+    n_channels,
     local_nbytes,
     global_nbytes,
     global_process_nbytes,
@@ -138,9 +139,10 @@ def write_compressed(
         stream_starts (array):  The local starting byte offsets for each stream.
         global_stream_starts (array):  The global starting byte offsets for each stream.
         stream_nbytes (array):  The local number of bytes for each stream.
-        stream_offsets (array):  The offsets used in int32 conversion.
-        stream_gains (array):  The gains used in int32 conversion.
+        stream_offsets (array):  The offsets used in int conversion.
+        stream_gains (array):  The gains used in int conversion.
         compressed (array):  The compressed bytes.
+        n_channels (int):  The number of FLAC channels used (1 or 2).
         local_nbytes (int):  The total number of local compressed bytes.
         global_nbytes (int):  The total global compressed bytes.
         global_process_nbytes (list):  The number of compressed bytes on each process.
@@ -154,8 +156,8 @@ def write_compressed(
     if not have_hdf5:
         raise RuntimeError("h5py is not importable, cannot write to HDF5")
 
-    # Writer is currently using version 0
-    from .hdf5_load_v0 import hdf5_names as hnames
+    # Writer is currently using version 1
+    from .hdf5_load_v1 import hdf5_names as hnames
 
     comm = mpi_comm
 
@@ -177,8 +179,9 @@ def write_compressed(
     if rank == 0 or not use_serial:
         # This process is participating.  Write the format version string
         # to the top-level group.
-        hgrp.attrs["flacarray_format_version"] = 0
+        hgrp.attrs["flacarray_format_version"] = "1"
         hgrp.attrs["flacarray_software_version"] = flacarray_version
+        hgrp.attrs[hnames["flac_channels"]] = f"{n_channels}"
 
         # Create the datasets.  We create the start bytes and auxiliary datasets first
         # and attach any metadata keys to the start bytes dataset (which is always
@@ -328,6 +331,12 @@ def write_array(
     global_shape = global_props["shape"]
     mpi_dist = global_props["dist"]
 
+    # Get the number of channels
+    if arr.dtype == np.dtype(np.int64) or arr.dtype == np.dtype(np.float64):
+        n_channels = 2
+    else:
+        n_channels = 1
+
     # Compress our local piece of the array
     compressed, starts, nbytes, offsets, gains = array_compress(
         arr, level=level, quanta=quanta, precision=precision, use_threads=use_threads
@@ -355,6 +364,7 @@ def write_array(
         offsets,
         gains,
         compressed,
+        n_channels,
         local_nbytes,
         global_nbytes,
         global_proc_bytes,

--- a/src/flacarray/hdf5_load_v0.py
+++ b/src/flacarray/hdf5_load_v0.py
@@ -141,7 +141,7 @@ def read_compressed(hgrp, keep=None, mpi_comm=None, mpi_dist=None):
     if rank == 0 or not use_serial:
         # This process is participating.
         # Double check that we can load this format.
-        ver = hgrp.attrs["flacarray_format_version"]
+        ver = int(hgrp.attrs["flacarray_format_version"])
         if ver != 0:
             msg = f"Version 0 loader called with version {ver} data"
             raise RuntimeError(msg)
@@ -258,10 +258,15 @@ def read_compressed(hgrp, keep=None, mpi_comm=None, mpi_dist=None):
             local_shape = None
         else:
             local_shape = local_starts.shape + (stream_size,)
+
+    # For version 0, the number of channels is always "1", since int64 flac encoding
+    # was not yet supported.  We handle the int64 case in the read_array() function.
+
     return (
         local_shape,
         global_shape,
         compressed,
+        1,
         local_starts,
         stream_nbytes,
         stream_offsets,
@@ -323,6 +328,7 @@ def read_array(
         local_shape,
         global_shape,
         compressed,
+        n_channel,
         stream_starts,
         stream_nbytes,
         stream_offsets,
@@ -344,17 +350,58 @@ def read_array(
         first_samp = stream_slice.start
         last_samp = stream_slice.stop
 
-    arr = array_decompress(
-        compressed,
-        local_shape[-1],
-        stream_starts,
-        stream_nbytes,
-        stream_offsets=stream_offsets,
-        stream_gains=stream_gains,
-        first_stream_sample=first_samp,
-        last_stream_sample=last_samp,
-        use_threads=use_threads,
-    )
+    # Check for legacy int64 storage format.  Version 0 used 32bit integers plus
+    # an offset to encode a subset of 64bit integers.
+
+    if stream_offsets is not None:
+        if stream_gains is None:
+            # Legacy int64 format.  First decompress the 32bit integers
+            arr = array_decompress(
+                compressed,
+                local_shape[-1],
+                stream_starts,
+                stream_nbytes,
+                stream_offsets=None,
+                stream_gains=None,
+                first_stream_sample=first_samp,
+                last_stream_sample=last_samp,
+                use_threads=use_threads,
+            )
+            # Now add the stream offsets
+            ext_shape = stream_offsets.shape + (1,)
+            arr = arr.astype(np.int64) + stream_offsets.reshape(ext_shape)
+        else:
+            # Either float32 or float64.  Version 0 used the data type of offsets
+            # and gains to determine this, which was fragile.  We decompress the
+            # data as float32 and then promote if needed.
+            arr = array_decompress(
+                compressed,
+                local_shape[-1],
+                stream_starts,
+                stream_nbytes,
+                stream_offsets=stream_offsets,
+                stream_gains=stream_gains,
+                first_stream_sample=first_samp,
+                last_stream_sample=last_samp,
+                use_threads=use_threads,
+            )
+            if stream_gains.dtype == np.dtype(np.float64):
+                # We want float64
+                arr = arr.astype(np.float64)
+    else:
+        # int32
+        arr = array_decompress(
+            compressed,
+            local_shape[-1],
+            stream_starts,
+            stream_nbytes,
+            stream_offsets=None,
+            stream_gains=None,
+            first_stream_sample=first_samp,
+            last_stream_sample=last_samp,
+            use_threads=use_threads,
+        )
+
     if keep_indices:
         return arr, indices
     else:

--- a/src/flacarray/hdf5_load_v1.py
+++ b/src/flacarray/hdf5_load_v1.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
-"""Loading functions for Zarr format version 0.
+"""Loading functions for HDF5 format version 1.
 
 This module should only be imported on-demand by the higher-level read / write
 functions.
@@ -9,26 +9,30 @@ functions.
 """
 import numpy as np
 
-import zarr
-
 from .decompress import array_decompress
+from .hdf5_utils import hdf5_use_serial
 from .mpi import distribute_and_verify
-from .io_common import read_send_compressed
+from .io_common import (
+    read_send_compressed,
+    select_keep_indices,
+    read_compressed_dataset_slice,
+)
 from .utils import function_timer, log
 
 
 """The dataset and attribute names."""
-zarr_names = {
+hdf5_names = {
     "compressed": "compressed",
     "stream_starts": "stream_starts",
     "stream_bytes": "stream_bytes",
     "stream_size": "stream_size",
     "stream_offsets": "stream_offsets",
     "stream_gains": "stream_gains",
+    "flac_channels": "flac_channels",
 }
 
 
-class ReaderZarr:
+class ReaderHDF5:
     """Helper class for the common reader function."""
 
     def __init__(
@@ -69,7 +73,7 @@ class ReaderZarr:
             return None
         shape = tuple([x.stop - x.start for x in dslc])
         raw = np.empty(shape, dtype=dset.dtype)
-        raw[dslc] = dset[fslc]
+        dset.read_direct(raw, fslc, dslc)
         return raw
 
     def load_starts(self, mpi_comm, fslc, dslc):
@@ -86,8 +90,11 @@ class ReaderZarr:
 
 
 @function_timer
-def read_compressed(zgrp, keep=None, mpi_comm=None, mpi_dist=None):
-    """Load compressed data from an Zarr Group.
+def read_compressed(hgrp, keep=None, mpi_comm=None, mpi_dist=None):
+    """Load compressed data from an HDF group.
+
+    If `stream_slice` is specified, the returned array will have only that
+    range of samples in the final dimension.
 
     If `keep` is specified, this should be a boolean array with the same shape
     as the leading dimensions of the original array.  True values in this array
@@ -98,7 +105,7 @@ def read_compressed(zgrp, keep=None, mpi_comm=None, mpi_dist=None):
     streams corresponding to True values in the `keep` mask.
 
     Args:
-        zgrp (zarr.Group):  The group to read.
+        hgrp (h5py.Group):  The group to read.
         keep (array):  Bool array of streams to keep in the decompression.
         mpi_comm (MPI.Comm):  The optional MPI communicator over which to distribute
             the leading dimension of the array.
@@ -109,6 +116,8 @@ def read_compressed(zgrp, keep=None, mpi_comm=None, mpi_dist=None):
         (tuple):  The compressed data and metadata.
 
     """
+    use_serial = hdf5_use_serial(hgrp, mpi_comm)
+
     if mpi_comm is None:
         nproc = 1
         rank = 0
@@ -130,31 +139,32 @@ def read_compressed(zgrp, keep=None, mpi_comm=None, mpi_dist=None):
     dsgain = None
     dcomp = None
 
-    if rank == 0:
+    if rank == 0 or not use_serial:
         # This process is participating.
         # Double check that we can load this format.
-        ver = int(zgrp.attrs["flacarray_format_version"])
-        if ver != 0:
-            msg = f"Version 0 loader called with version {ver} data"
+        ver = int(hgrp.attrs["flacarray_format_version"])
+        if ver != 1:
+            msg = f"Version 1 loader called with version {ver} data"
             raise RuntimeError(msg)
 
         # Get a handle to all the datasets, and extract some metadata.
-        dstarts = zgrp[zarr_names["stream_starts"]]
-        stream_size = int(dstarts.attrs[zarr_names["stream_size"]])
+        n_channel = int(hgrp.attrs[hdf5_names["flac_channels"]])
+        dstarts = hgrp[hdf5_names["stream_starts"]]
+        stream_size = int(dstarts.attrs[hdf5_names["stream_size"]])
         global_shape = dstarts.shape + (stream_size,)
-        dbytes = zgrp[zarr_names["stream_bytes"]]
+        dbytes = hgrp[hdf5_names["stream_bytes"]]
         dsoff = None
-        if zarr_names["stream_offsets"] in zgrp:
-            dsoff = zgrp[zarr_names["stream_offsets"]]
+        if hdf5_names["stream_offsets"] in hgrp:
+            dsoff = hgrp[hdf5_names["stream_offsets"]]
             stream_off_dtype = np.dtype(dsoff.dtype)
         dsgain = None
-        if zarr_names["stream_gains"] in zgrp:
-            dsgain = zgrp[zarr_names["stream_gains"]]
+        if hdf5_names["stream_gains"] in hgrp:
+            dsgain = hgrp[hdf5_names["stream_gains"]]
             stream_gain_dtype = np.dtype(dsgain.dtype)
-        dcomp = zgrp[zarr_names["compressed"]]
+        dcomp = hgrp[hdf5_names["compressed"]]
         global_nbytes = dcomp.size
 
-    if nproc > 1:
+    if nproc > 1 and use_serial:
         # Not every process is reading- communicate some of the metadata loaded
         # above.
         stream_size = mpi_comm.bcast(stream_size, root=0)
@@ -162,38 +172,100 @@ def read_compressed(zgrp, keep=None, mpi_comm=None, mpi_dist=None):
         global_nbytes = mpi_comm.bcast(global_nbytes, root=0)
         stream_gain_dtype = mpi_comm.bcast(stream_gain_dtype, root=0)
         stream_off_dtype = mpi_comm.bcast(stream_off_dtype, root=0)
+        n_channel = mpi_comm.bcast(n_channel, root=0)
+    global_leading_shape = global_shape[:-1]
 
     # Compute or verify the MPI distribution for the global leading dimension
     mpi_dist = distribute_and_verify(mpi_comm, global_shape[0], mpi_dist=mpi_dist)
 
-    # Use the common reader function
-    reader = ReaderZarr(
-        dstarts, dbytes, dcomp, dsoff, dsgain, stream_off_dtype, stream_gain_dtype
-    )
-    (
-        local_shape,
-        local_starts,
-        stream_nbytes,
-        compressed,
-        stream_offsets,
-        stream_gains,
-        keep_indices,
-    ) = read_send_compressed(
-        reader,
-        global_shape,
-        keep=keep,
-        mpi_comm=mpi_comm,
-        mpi_dist=mpi_dist,
-    )
+    # Local data buffers we will load from the file.
+    local_shape = None
+    local_starts = None
+    stream_nbytes = None
+    compressed = None
+    stream_offsets = None
+    stream_gains = None
+    keep_indices = None
 
-    # For version 0, the number of channels is always "1", since int64 flac encoding
-    # was not yet supported.  We handle the int64 case in the read_array() function.
+    if use_serial:
+        # Use the common function for reading data and communicating it.
+        reader = ReaderHDF5(
+            dstarts, dbytes, dcomp, dsoff, dsgain, stream_off_dtype, stream_gain_dtype
+        )
+        (
+            local_shape,
+            local_starts,
+            stream_nbytes,
+            compressed,
+            stream_offsets,
+            stream_gains,
+            keep_indices,
+        ) = read_send_compressed(
+            reader,
+            global_shape,
+            keep=keep,
+            mpi_comm=mpi_comm,
+            mpi_dist=mpi_dist,
+        )
+    else:
+        # We are using parallel HDF5.  All processes have a handle to the dataset
+        # from above, and each process reads its local slice.
+        ds_range = mpi_dist[rank]
+        leading_shape = (ds_range[1] - ds_range[0],) + global_leading_shape[1:]
+        local_shape = leading_shape + (stream_size,)
 
+        # The helper datasets all have the same slab definitions
+        dslc = tuple([slice(0, x) for x in leading_shape])
+        hslc = (slice(ds_range[0], ds_range[0] + leading_shape[0]),) + tuple(
+            [slice(0, x) for x in leading_shape[1:]]
+        )
+
+        # If we are using the "keep" array to select streams, slice that
+        # to cover only data for this process.
+        if keep is None:
+            proc_keep = None
+        else:
+            proc_keep = keep[dslc]
+
+        # Stream starts
+        raw_starts = np.empty(leading_shape, dtype=dstarts.dtype)
+        dstarts.read_direct(raw_starts, hslc, dslc)
+
+        # Stream nbytes
+        raw_nbytes = np.empty(leading_shape, dtype=dstarts.dtype)
+        dbytes.read_direct(raw_nbytes, hslc, dslc)
+
+        # Offsets and gains for type conversions
+        raw_offsets = None
+        if dsoff is not None:
+            raw_offsets = np.empty(leading_shape, dtype=stream_off_dtype)
+            dsoff.read_direct(raw_offsets, hslc, dslc)
+        raw_gains = None
+        if dsgain is not None:
+            raw_gains = np.empty(leading_shape, dtype=stream_gain_dtype)
+            dsgain.read_direct(raw_gains, hslc, dslc)
+
+        # Compressed bytes.  Apply our stream selection and load just those
+        # streams we are keeping for this process.
+        compressed, local_starts, keep_indices = read_compressed_dataset_slice(
+            dcomp, proc_keep, raw_starts, raw_nbytes
+        )
+
+        # Cut our other arrays to only include the indices selected by the keep mask.
+        stream_nbytes = select_keep_indices(raw_nbytes, keep_indices)
+        stream_offsets = select_keep_indices(raw_offsets, keep_indices)
+        stream_gains = select_keep_indices(raw_gains, keep_indices)
+
+        if local_starts is None:
+            # This rank has no data after masking
+            local_shape = None
+        else:
+            local_shape = local_starts.shape + (stream_size,)
     return (
         local_shape,
         global_shape,
         compressed,
-        1,
+        n_channel,
         local_starts,
         stream_nbytes,
         stream_offsets,
@@ -205,7 +277,7 @@ def read_compressed(zgrp, keep=None, mpi_comm=None, mpi_dist=None):
 
 @function_timer
 def read_array(
-    zgrp,
+    hgrp,
     keep=None,
     stream_slice=None,
     keep_indices=False,
@@ -234,7 +306,7 @@ def read_array(
     is returned containing the indices of each stream that was kept.
 
     Args:
-        zgrp (zarr.Group):  The group to read.
+        hgrp (h5py.Group):  The group to read.
         keep (array):  Bool array of streams to keep in the decompression.
         stream_slice (slice):  A python slice with step size of one, indicating
             the sample range to extract from each stream.
@@ -263,7 +335,7 @@ def read_array(
         mpi_dist,
         indices,
     ) = read_compressed(
-        zgrp,
+        hgrp,
         keep=keep,
         mpi_comm=mpi_comm,
         mpi_dist=mpi_dist,
@@ -277,58 +349,18 @@ def read_array(
         first_samp = stream_slice.start
         last_samp = stream_slice.stop
 
-    # Check for legacy int64 storage format.  Version 0 used 32bit integers plus
-    # an offset to encode a subset of 64bit integers.
-
-    if stream_offsets is not None:
-        if stream_gains is None:
-            # Legacy int64 format.  First decompress the 32bit integers
-            arr = array_decompress(
-                compressed,
-                local_shape[-1],
-                stream_starts,
-                stream_nbytes,
-                stream_offsets=None,
-                stream_gains=None,
-                first_stream_sample=first_samp,
-                last_stream_sample=last_samp,
-                use_threads=use_threads,
-            )
-            # Now add the stream offsets
-            ext_shape = stream_offsets.shape + (1,)
-            arr = arr.astype(np.int64) + stream_offsets.reshape(ext_shape)
-        else:
-            # Either float32 or float64.  Version 0 used the data type of offsets
-            # and gains to determine this, which was fragile.  We decompress the
-            # data as float32 and then promote if needed.
-            arr = array_decompress(
-                compressed,
-                local_shape[-1],
-                stream_starts,
-                stream_nbytes,
-                stream_offsets=stream_offsets,
-                stream_gains=stream_gains,
-                first_stream_sample=first_samp,
-                last_stream_sample=last_samp,
-                use_threads=use_threads,
-            )
-            if stream_gains.dtype == np.dtype(np.float64):
-                # We want float64
-                arr = arr.astype(np.float64)
-    else:
-        # int32
-        arr = array_decompress(
-            compressed,
-            local_shape[-1],
-            stream_starts,
-            stream_nbytes,
-            stream_offsets=None,
-            stream_gains=None,
-            first_stream_sample=first_samp,
-            last_stream_sample=last_samp,
-            use_threads=use_threads,
-        )
-
+    arr = array_decompress(
+        compressed,
+        local_shape[-1],
+        stream_starts,
+        stream_nbytes,
+        stream_offsets=stream_offsets,
+        stream_gains=stream_gains,
+        first_stream_sample=first_samp,
+        last_stream_sample=last_samp,
+        use_threads=use_threads,
+        is_int64=(n_channel == 2),
+    )
     if keep_indices:
         return arr, indices
     else:

--- a/src/flacarray/libflacarray/compress.c
+++ b/src/flacarray/libflacarray/compress.c
@@ -142,11 +142,16 @@ void _free_compressed(ArrayUint8 ** buffers, int64_t n_stream) {
 // attempt is made to free any buffers that were allocated, and an error code is
 // returned which is a bitwise OR of the errors on all threads.
 
+// NOTE:  libFLAC >= 1.5.0 natively supports threaded compression, but this is not
+// enabled by default.  We could evaluate the performance of that, but would require
+// a check on the version being used.
+
 // Unthreaded version.  No need for thread-local buffers, so this is often faster.
 int encode(
     int32_t * const data,
     int64_t n_stream,
     int64_t stream_size,
+    uint32_t n_channels,
     uint32_t level,
     int64_t * n_bytes,
     int64_t * starts,
@@ -204,7 +209,7 @@ int encode(
             errors |= ERROR_ENCODE_SET_BLOCK_SIZE;
             continue;
         }
-        success = FLAC__stream_encoder_set_channels(encoder, 1);
+        success = FLAC__stream_encoder_set_channels(encoder, n_channels);
         if (!success) {
             errors |= ERROR_ENCODE_SET_CHANNELS;
             continue;
@@ -232,7 +237,7 @@ int encode(
         // Encode this stream.
         success = FLAC__stream_encoder_process_interleaved(
             encoder,
-            &(data[istream * stream_size]),
+            &(data[istream * stream_size * n_channels]),
             stream_size
         );
         if (!success) {
@@ -287,6 +292,7 @@ int encode_threaded(
     int32_t * const data,
     int64_t n_stream,
     int64_t stream_size,
+    uint32_t n_channels,
     uint32_t level,
     int64_t * n_bytes,
     int64_t * starts,
@@ -356,7 +362,7 @@ int encode_threaded(
                 errors |= ERROR_ENCODE_SET_BLOCK_SIZE;
                 continue;
             }
-            success = FLAC__stream_encoder_set_channels(encoder, 1);
+            success = FLAC__stream_encoder_set_channels(encoder, n_channels);
             if (!success) {
                 errors |= ERROR_ENCODE_SET_CHANNELS;
                 continue;
@@ -384,7 +390,7 @@ int encode_threaded(
             // Encode this stream.
             success = FLAC__stream_encoder_process_interleaved(
                 encoder,
-                &(data[istream * stream_size]),
+                &(data[istream * stream_size * n_channels]),
                 stream_size
             );
             if (!success) {
@@ -445,3 +451,107 @@ int encode_threaded(
     return errors;
 }
 
+
+// Helper wrappers for 32bit and 64bit integers.
+
+int encode_i32(
+    int32_t * const data,
+    int64_t n_stream,
+    int64_t stream_size,
+    uint32_t level,
+    int64_t * n_bytes,
+    int64_t * starts,
+    unsigned char ** bytes
+) {
+    return encode(
+        data,
+        n_stream,
+        stream_size,
+        1,
+        level,
+        n_bytes,
+        starts,
+        bytes
+    );
+}
+
+int encode_i32_threaded(
+    int32_t * const data,
+    int64_t n_stream,
+    int64_t stream_size,
+    uint32_t level,
+    int64_t * n_bytes,
+    int64_t * starts,
+    unsigned char ** bytes
+) {
+    return encode_threaded(
+        data,
+        n_stream,
+        stream_size,
+        1,
+        level,
+        n_bytes,
+        starts,
+        bytes
+    );
+}
+
+int encode_i64(
+    int64_t * const data,
+    int64_t n_stream,
+    int64_t stream_size,
+    uint32_t level,
+    int64_t * n_bytes,
+    int64_t * starts,
+    unsigned char ** bytes
+) {
+    int64_t n_elem = n_stream * stream_size;
+    int32_t * interleaved;
+    int err = get_interleaved(n_elem, data, &interleaved);
+    if (err != ERROR_NONE) {
+        return err;
+    }
+    copy_interleaved_64_to_32(n_elem, data, interleaved);
+    err = encode(
+        interleaved,
+        n_stream,
+        stream_size,
+        2,
+        level,
+        n_bytes,
+        starts,
+        bytes
+    );
+    free_interleaved(interleaved);
+    return err;
+}
+
+int encode_i64_threaded(
+    int64_t * const data,
+    int64_t n_stream,
+    int64_t stream_size,
+    uint32_t level,
+    int64_t * n_bytes,
+    int64_t * starts,
+    unsigned char ** bytes
+) {
+    int64_t n_elem = n_stream * stream_size;
+    int32_t * interleaved;
+    int err = get_interleaved(n_elem, data, &interleaved);
+    if (err != ERROR_NONE) {
+        return err;
+    }
+    copy_interleaved_64_to_32(n_elem, data, interleaved);
+    err = encode_threaded(
+        interleaved,
+        n_stream,
+        stream_size,
+        2,
+        level,
+        n_bytes,
+        starts,
+        bytes
+    );
+    free_interleaved(interleaved);
+    return err;
+}

--- a/src/flacarray/libflacarray/decompress.c
+++ b/src/flacarray/libflacarray/decompress.c
@@ -12,14 +12,27 @@
 
 typedef struct {
     unsigned char const * input;
+    // Total number of streams
     int64_t n_stream;
+    // The number of samples to decode from all streams
     int64_t n_decode;
+    // The number of channels in a single sample of a single stream
+    uint32_t n_channels;
+    // The current stream that is being decoded
     int64_t cur_stream;
+    // The starting byte of the current stream in the compressed input
     int64_t stream_start;
+    // The ending byte of the current stream in the compressed input
     int64_t stream_end;
+    // The current byte position in the compressed input
     int64_t stream_pos;
+    // The number of decompressed samples processed so far in this stream
     int64_t decomp_nelem;
+    // The decompressed and interleaved output for the current stream.  This
+    // points to the beginning of the output stream in the larger output
+    // buffer, and each stream has n_decode * n_channels int32 values.
     int32_t * decompressed;
+    // The current error state
     int32_t err;
 } dec_callback_data;
 
@@ -79,7 +92,9 @@ FLAC__StreamDecoderReadStatus dec_read_callback(
 
 
 // Write callback function, called by the decoder to process the output
-// decompressed integers.
+// decompressed integers.  This will be called on each frame, and the
+// input buffer is an array of pointers, one per channel.  We take the
+// data from each channel and interleave these into the extracted data.
 FLAC__StreamDecoderWriteStatus dec_write_callback(
     const FLAC__StreamDecoder * decoder,
     const FLAC__Frame * frame,
@@ -90,22 +105,28 @@ FLAC__StreamDecoderWriteStatus dec_write_callback(
     int64_t nelem = callback_data->decomp_nelem;
     int64_t n_decode = callback_data->n_decode;
     int32_t * decomp = callback_data->decompressed;
+    uint32_t n_chan = callback_data->n_channels;
+
+    // The maximum number of samples in each channel
     uint32_t blocksize = frame->header.blocksize;
 
-    // The number of bytes to copy might be smaller than blocksize, if we are on the
+    // The number of samples to copy might be smaller than blocksize, if we are on the
     // last block.
     int64_t n_copy = blocksize;
     if (nelem + blocksize > n_decode) {
         n_copy = n_decode - nelem;
     }
 
-    memcpy(
-        (void*)(decomp + nelem),
-        (void*)buffer[0],
-        n_copy * sizeof(int32_t)
-    );
+    // Copy data from all channels into our interleaved output buffer.
+    int64_t offset;
+    for (uint32_t chan = 0; chan < n_chan; ++chan) {
+        for (int32_t isamp = 0; isamp < n_copy; ++isamp) {
+            offset = n_chan * (nelem + isamp);
+            decomp[offset + chan] = buffer[chan][isamp];
+        }
+    }
 
-    // Increment our number of decoded elements
+    // Increment our number of decoded samples
     callback_data->decomp_nelem += n_copy;
 
     return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
@@ -208,6 +229,7 @@ int decode(
     int64_t * const nbytes,
     int64_t n_stream,
     int64_t stream_size,
+    uint32_t n_channels,
     int64_t first_sample,
     int64_t last_sample,
     int32_t * data,
@@ -246,6 +268,7 @@ int decode(
         callback_data.input = bytes;
         callback_data.n_stream = n_stream;
         callback_data.n_decode = n_decode;
+        callback_data.n_channels = n_channels;
         callback_data.err = ERROR_NONE;
 
         #pragma omp for schedule(static)
@@ -260,7 +283,7 @@ int decode(
             callback_data.stream_pos = starts[istream];
             callback_data.decomp_nelem = 0;
             // Set the output buffer to the address of the beginning of this stream.
-            callback_data.decompressed = data + n_decode * istream;
+            callback_data.decompressed = data + istream * n_decode * n_channels;
 
             decoder = FLAC__stream_decoder_new();
 
@@ -321,3 +344,64 @@ int decode(
     return errors;
 }
 
+
+// Helper functions for int32 and int64
+
+int decode_i32 (
+    unsigned char * const bytes,
+    int64_t * const starts,
+    int64_t * const nbytes,
+    int64_t n_stream,
+    int64_t stream_size,
+    int64_t first_sample,
+    int64_t last_sample,
+    int32_t * data,
+    bool use_threads
+) {
+    return decode(
+        bytes,
+        starts,
+        nbytes,
+        n_stream,
+        stream_size,
+        1,
+        first_sample,
+        last_sample,
+        data,
+        use_threads
+    );
+}
+
+int decode_i64 (
+    unsigned char * const bytes,
+    int64_t * const starts,
+    int64_t * const nbytes,
+    int64_t n_stream,
+    int64_t stream_size,
+    int64_t first_sample,
+    int64_t last_sample,
+    int64_t * data,
+    bool use_threads
+) {
+    int64_t n_elem = n_stream * stream_size;
+    int32_t * interleaved;
+    int err = get_interleaved(n_elem, data, &interleaved);
+    if (err != ERROR_NONE) {
+        return err;
+    }
+    err = decode(
+        bytes,
+        starts,
+        nbytes,
+        n_stream,
+        stream_size,
+        2,
+        first_sample,
+        last_sample,
+        interleaved,
+        use_threads
+    );
+    copy_interleaved_32_to_64(n_elem, interleaved, data);
+    free_interleaved(interleaved);
+    return err;
+}

--- a/src/flacarray/libflacarray/flacarray.h
+++ b/src/flacarray/libflacarray/flacarray.h
@@ -43,19 +43,9 @@ typedef struct {
     unsigned char * data;
 } ArrayUint8;
 
-typedef struct {
-    int64_t size;
-    int64_t n_elem;
-    int32_t * data;
-} ArrayInt32;
-
 ArrayUint8 * create_array_uint8(int64_t start_size);
 void destroy_array_uint8(ArrayUint8 * obj);
 int resize_array_uint8(ArrayUint8 * obj, int64_t new_size);
-
-ArrayInt32 * create_array_int32(int64_t start_size);
-void destroy_array_int32(ArrayInt32 * obj);
-int resize_array_int32(ArrayInt32 * obj, int64_t new_size);
 
 // Encoding
 
@@ -63,6 +53,7 @@ int encode(
     int32_t * const data,
     int64_t n_stream,
     int64_t stream_size,
+    uint32_t n_channels,
     uint32_t level,
     int64_t * n_bytes,
     int64_t * starts,
@@ -73,6 +64,7 @@ int encode_threaded(
     int32_t * const data,
     int64_t n_stream,
     int64_t stream_size,
+    uint32_t n_channels,
     uint32_t level,
     int64_t * n_bytes,
     int64_t * starts,
@@ -87,21 +79,91 @@ int decode(
     int64_t * const nbytes,
     int64_t n_stream,
     int64_t stream_size,
+    uint32_t n_channels,
     int64_t first_sample,
     int64_t last_sample,
     int32_t * data,
     bool use_threads
 );
 
-// Type conversion
+// Helper wrappers for int32 and int64 encode / decode.  int64 data is encoded
+// as 2 interleaved channels.
 
-int int64_to_int32(
-    int64_t const * input,
+bool is_little_endian();
+
+int get_interleaved(int64_t n_elem, int64_t const * data, int32_t ** interleaved);
+
+void copy_interleaved_64_to_32(int64_t n_elem, int64_t * input, int32_t * output);
+
+void copy_interleaved_32_to_64(int64_t n_elem, int32_t * input, int64_t * output);
+
+void free_interleaved(int32_t * interleaved);
+
+int encode_i32(
+    int32_t * const data,
     int64_t n_stream,
     int64_t stream_size,
-    int32_t * output,
-    int64_t * offsets
+    uint32_t level,
+    int64_t * n_bytes,
+    int64_t * starts,
+    unsigned char ** bytes
 );
+
+int encode_i32_threaded(
+    int32_t * const data,
+    int64_t n_stream,
+    int64_t stream_size,
+    uint32_t level,
+    int64_t * n_bytes,
+    int64_t * starts,
+    unsigned char ** bytes
+);
+
+int encode_i64(
+    int64_t * const data,
+    int64_t n_stream,
+    int64_t stream_size,
+    uint32_t level,
+    int64_t * n_bytes,
+    int64_t * starts,
+    unsigned char ** bytes
+);
+
+int encode_i64_threaded(
+    int64_t * const data,
+    int64_t n_stream,
+    int64_t stream_size,
+    uint32_t level,
+    int64_t * n_bytes,
+    int64_t * starts,
+    unsigned char ** bytes
+);
+
+int decode_i32(
+    unsigned char * const bytes,
+    int64_t * const starts,
+    int64_t * const nbytes,
+    int64_t n_stream,
+    int64_t stream_size,
+    int64_t first_sample,
+    int64_t last_sample,
+    int32_t * data,
+    bool use_threads
+);
+
+int decode_i64(
+    unsigned char * const bytes,
+    int64_t * const starts,
+    int64_t * const nbytes,
+    int64_t n_stream,
+    int64_t stream_size,
+    int64_t first_sample,
+    int64_t last_sample,
+    int64_t * data,
+    bool use_threads
+);
+
+// Type conversion
 
 int float32_to_int32(
     float const * input,
@@ -113,26 +175,18 @@ int float32_to_int32(
     float * gains
 );
 
-int float64_to_int32(
+int float64_to_int64(
     double const * input,
     int64_t n_stream,
     int64_t stream_size,
     double const * quanta,
-    int32_t * output,
+    int64_t * output,
     double * offsets,
     double * gains
 );
 
-void int32_to_int64(
-    int32_t const * input,
-    int64_t n_stream,
-    int64_t stream_size,
-    int64_t const * offsets,
-    int64_t * output
-);
-
-void int32_to_float64(
-    int32_t const * input,
+void int64_to_float64(
+    int64_t const * input,
     int64_t n_stream,
     int64_t stream_size,
     double const * offsets,

--- a/src/flacarray/libflacarray/libflacarray.pyx
+++ b/src/flacarray/libflacarray/libflacarray.pyx
@@ -9,13 +9,14 @@ cimport numpy as cnp
 
 cnp.import_array()
 
-flac_dtype = np.dtype(np.int32)
+flac_i32_dtype = np.dtype(np.int32)
+flac_i64_dtype = np.dtype(np.int64)
 compressed_dtype = np.dtype(np.uint8)
 offset_dtype = np.dtype(np.int64)
 
 
 cdef extern from "flacarray.h":
-    int encode(
+    int encode_i32(
         int32_t * data,
         int64_t n_stream,
         int64_t stream_size,
@@ -24,7 +25,7 @@ cdef extern from "flacarray.h":
         int64_t * starts,
         unsigned char ** rawbytes
     )
-    int encode_threaded(
+    int encode_i32_threaded(
         int32_t * data,
         int64_t n_stream,
         int64_t stream_size,
@@ -33,7 +34,25 @@ cdef extern from "flacarray.h":
         int64_t * starts,
         unsigned char ** rawbytes
     )
-    int decode(
+    int encode_i64(
+        int64_t * data,
+        int64_t n_stream,
+        int64_t stream_size,
+        uint32_t level,
+        int64_t * n_bytes,
+        int64_t * starts,
+        unsigned char ** rawbytes
+    )
+    int encode_i64_threaded(
+        int64_t * data,
+        int64_t n_stream,
+        int64_t stream_size,
+        uint32_t level,
+        int64_t * n_bytes,
+        int64_t * starts,
+        unsigned char ** rawbytes
+    )
+    int decode_i32(
         unsigned char * rawbytes,
         int64_t * starts,
         int64_t * nbytes,
@@ -44,12 +63,16 @@ cdef extern from "flacarray.h":
         int32_t * data,
         bool use_threads
     )
-    int int64_to_int32(
-        int64_t * input,
+    int decode_i64(
+        unsigned char * rawbytes,
+        int64_t * starts,
+        int64_t * nbytes,
         int64_t n_stream,
         int64_t stream_size,
-        int32_t * output,
-        int64_t * offsets
+        int64_t first_sample,
+        int64_t last_sample,
+        int64_t * data,
+        bool use_threads
     )
     int float32_to_int32(
         float * input,
@@ -60,24 +83,17 @@ cdef extern from "flacarray.h":
         float * offsets,
         float * gains
     )
-    int float64_to_int32(
+    int float64_to_int64(
         double * input,
         int64_t n_stream,
         int64_t stream_size,
         double * quanta,
-        int32_t * output,
+        int64_t * output,
         double * offsets,
         double * gains
     )
-    void int32_to_int64(
-        int32_t * input,
-        int64_t n_stream,
-        int64_t stream_size,
-        int64_t * offsets,
-        int64_t * output
-    )
-    void int32_to_float64(
-        int32_t * input,
+    void int64_to_float64(
+        int64_t * input,
         int64_t n_stream,
         int64_t stream_size,
         double * offsets,
@@ -92,46 +108,6 @@ cdef extern from "flacarray.h":
         float * gains,
         float * output
     )
-
-
-def wrap_int64_to_int32(
-    cnp.ndarray[cnp.int64_t, ndim=1, mode="c"] flatdata,
-    cnp.int64_t n_stream,
-    cnp.int64_t stream_size,
-):
-    """Convert an array of 64bit integer streams to 32bit.
-
-    For each stream, this finds the 64bit integer mean and subtracts it.  It then
-    checks that the stream values will fit in a 32bit integer representation.
-
-    Args:
-        flatdata (array):  The 64bit integer array.
-        n_stream (int64_t):  The number of streams.
-        stream_size (int64_t):  The length of each stream.
-
-    Returns:
-        (tuple):  The (integer data, offset array)
-
-    """
-    # Allocate the outputs
-    cdef int64_t size = n_stream * stream_size
-    cdef cnp.ndarray output = np.empty(size, dtype=np.int32, order="C")
-    cdef cnp.ndarray offsets = np.empty(n_stream, dtype=np.int64, order="C")
-
-    errcode = int64_to_int32(
-        <cnp.int64_t *>flatdata.data,
-        n_stream,
-        stream_size,
-        <cnp.int32_t *>output.data,
-        <cnp.int64_t *>offsets.data,
-    )
-
-    if errcode != 0:
-        # FIXME: change error codes so we can print a message here
-        msg = f"Encoding failed, return code = {errcode}"
-        raise RuntimeError(msg)
-
-    return (output, offsets)
 
 
 def wrap_float32_to_int32(
@@ -185,13 +161,13 @@ def wrap_float32_to_int32(
     return (output, offsets, gains)
 
 
-def wrap_float64_to_int32(
+def wrap_float64_to_int64(
     cnp.ndarray[double, ndim=1, mode="c"] flatdata,
     cnp.int64_t n_stream,
     cnp.int64_t stream_size,
     cnp.ndarray[double, ndim=1, mode="c"] quanta,
 ):
-    """Convert an array of 64bit float streams to 32bit integers.
+    """Convert an array of 64bit float streams to 64bit integers.
 
     This function subtracts the mean and rescales data before rounding to 32bit
     integer values.
@@ -210,7 +186,7 @@ def wrap_float64_to_int32(
     """
     # Allocate the outputs
     cdef int64_t size = n_stream * stream_size
-    cdef cnp.ndarray output = np.empty(size, dtype=np.int32, order="C")
+    cdef cnp.ndarray output = np.empty(size, dtype=np.int64, order="C")
     cdef cnp.ndarray offsets = np.empty(n_stream, dtype=np.float64, order="C")
     cdef cnp.ndarray gains = np.empty(n_stream, dtype=np.float64, order="C")
 
@@ -218,12 +194,12 @@ def wrap_float64_to_int32(
     if len(quanta) == n_stream:
         fquanta = <double *>quanta.data
 
-    errcode = float64_to_int32(
+    errcode = float64_to_int64(
         <double *>flatdata.data,
         n_stream,
         stream_size,
         fquanta,
-        <cnp.int32_t *>output.data,
+        <cnp.int64_t *>output.data,
         <double *>offsets.data,
         <double *>gains.data,
     )
@@ -234,38 +210,6 @@ def wrap_float64_to_int32(
         raise RuntimeError(msg)
 
     return (output, offsets, gains)
-
-
-def wrap_int32_to_int64(
-    cnp.ndarray[cnp.int32_t, ndim=1, mode="c"] idata,
-    cnp.int64_t n_stream,
-    cnp.int64_t stream_size,
-    cnp.ndarray[cnp.int64_t, ndim=1, mode="c"] offsets,
-):
-    """Restore int32 data to int64, while applying the offset.
-
-    Args:
-        idata (array):  The 32bit integer array.
-        n_stream (int64_t):  The number of streams.
-        stream_size (int64_t):  The length of each stream.
-        offsets (array):  The stream offsets.
-
-    Returns:
-        (array):  The output data.
-
-    """
-    # Allocate the outputs
-    cdef int64_t size = n_stream * stream_size
-    cdef cnp.ndarray output = np.empty(size, dtype=np.int64, order="C")
-
-    int32_to_int64(
-        <cnp.int32_t *>idata.data,
-        n_stream,
-        stream_size,
-        <cnp.int64_t *>offsets.data,
-        <cnp.int64_t *>output.data,
-    )
-    return output
 
 
 def wrap_int32_to_float32(
@@ -303,17 +247,17 @@ def wrap_int32_to_float32(
     return output
 
 
-def wrap_int32_to_float64(
-    cnp.ndarray[cnp.int32_t, ndim=1, mode="c"] idata,
+def wrap_int64_to_float64(
+    cnp.ndarray[cnp.int64_t, ndim=1, mode="c"] idata,
     cnp.int64_t n_stream,
     cnp.int64_t stream_size,
     cnp.ndarray[double, ndim=1, mode="c"] offsets,
     cnp.ndarray[double, ndim=1, mode="c"] gains,
 ):
-    """Restore int32 data to float32.
+    """Restore int64 data to float64.
 
     Args:
-        idata (array):  The 32bit integer array.
+        idata (array):  The 64bit integer array.
         n_stream (int64_t):  The number of streams.
         stream_size (int64_t):  The length of each stream.
         offsets (array):  The stream offsets.
@@ -327,8 +271,8 @@ def wrap_int32_to_float64(
     cdef int64_t size = n_stream * stream_size
     cdef cnp.ndarray output = np.empty(size, dtype=np.float64, order="C")
 
-    int32_to_float64(
-        <cnp.int32_t *>idata.data,
+    int64_to_float64(
+        <cnp.int64_t *>idata.data,
         n_stream,
         stream_size,
         <double *>offsets.data,
@@ -338,13 +282,13 @@ def wrap_int32_to_float64(
     return output
 
 
-def wrap_encode(
+def wrap_encode_i32(
     cnp.ndarray[cnp.int32_t, ndim=1, mode="c"] flatdata,
     cnp.int64_t n_stream,
     cnp.int64_t stream_size,
     cnp.uint32_t level,
 ):
-    """Wrapper around the C encode function.
+    """Wrapper around the C int32 encode function.
 
     This does some data setup, but works with a flat-packed version of
     the input array.
@@ -368,7 +312,7 @@ def wrap_encode(
     cdef unsigned char * rawbytes
     cdef int errcode = 0
 
-    errcode = encode(
+    errcode = encode_i32(
         <cnp.int32_t *>flatdata.data,
         n_stream,
         stream_size,
@@ -399,13 +343,13 @@ def wrap_encode(
     )
 
 
-def wrap_encode_threaded(
+def wrap_encode_i32_threaded(
     cnp.ndarray[cnp.int32_t, ndim=1, mode="c"] flatdata,
     cnp.int64_t n_stream,
     cnp.int64_t stream_size,
     cnp.uint32_t level,
 ):
-    """Wrapper around the C encode function (threaded version).
+    """Wrapper around the C int32 encode function (threaded version).
 
     This does some data setup, but works with a flat-packed version of
     the input array.
@@ -429,8 +373,130 @@ def wrap_encode_threaded(
     cdef unsigned char * rawbytes
     cdef int errcode = 0
 
-    errcode = encode_threaded(
+    errcode = encode_i32_threaded(
         <cnp.int32_t *>flatdata.data,
+        n_stream,
+        stream_size,
+        level,
+        &n_bytes,
+        <cnp.int64_t *>flat_starts.data,
+        &rawbytes,
+    )
+
+    if errcode != 0:
+        # FIXME: change error codes so we can print a message here
+        msg = f"Encoding failed, return code = {errcode}"
+        raise RuntimeError(msg)
+
+    # Compute the bytes per stream
+    flat_nbytes[:-1] = np.diff(flat_starts)
+    flat_nbytes[-1] = n_bytes - flat_starts[-1]
+
+    # Wrap the returned C-allocated buffers so that they are properly garbage
+    # collected.
+    cdef cvarray compressed = <cnp.uint8_t[:n_bytes]> rawbytes
+    compressed.free_data = True
+
+    return (
+        np.asarray(compressed),
+        flat_starts,
+        flat_nbytes,
+    )
+
+
+def wrap_encode_i64(
+    cnp.ndarray[cnp.int64_t, ndim=1, mode="c"] flatdata,
+    cnp.int64_t n_stream,
+    cnp.int64_t stream_size,
+    cnp.uint32_t level,
+):
+    """Wrapper around the C int64 encode function.
+
+    This does some data setup, but works with a flat-packed version of
+    the input array.
+
+    Args:
+        flatdata (array):  The 1D reshaped view of the data.
+        n_stream (int64_t):  The number of streams.
+        stream_size (int64_t):  The length of each stream.
+        level (uint32_t):  The compression level (0-8).
+
+    Returns:
+        (tuple): The (compressed bytes, flat-packed starting bytes,
+            flat-packed stream bytes).
+
+    """
+    # Allocate the array of starts
+    cdef cnp.ndarray flat_starts = np.empty(n_stream, dtype=np.int64, order="C")
+    cdef cnp.ndarray flat_nbytes = np.empty(n_stream, dtype=np.int64, order="C")
+
+    cdef int64_t n_bytes
+    cdef unsigned char * rawbytes
+    cdef int errcode = 0
+
+    errcode = encode_i64(
+        <cnp.int64_t *>flatdata.data,
+        n_stream,
+        stream_size,
+        level,
+        &n_bytes,
+        <cnp.int64_t *>flat_starts.data,
+        &rawbytes,
+    )
+
+    if errcode != 0:
+        # FIXME: change error codes so we can print a message here
+        msg = f"Encoding failed, return code = {errcode}"
+        raise RuntimeError(msg)
+
+    # Compute the bytes per stream
+    flat_nbytes[:-1] = np.diff(flat_starts)
+    flat_nbytes[-1] = n_bytes - flat_starts[-1]
+
+    # Wrap the returned C-allocated buffers so that they are properly garbage
+    # collected.
+    cdef cvarray compressed = <cnp.uint8_t[:n_bytes]> rawbytes
+    compressed.free_data = True
+
+    return (
+        np.asarray(compressed),
+        flat_starts,
+        flat_nbytes,
+    )
+
+
+def wrap_encode_i64_threaded(
+    cnp.ndarray[cnp.int64_t, ndim=1, mode="c"] flatdata,
+    cnp.int64_t n_stream,
+    cnp.int64_t stream_size,
+    cnp.uint32_t level,
+):
+    """Wrapper around the C int64 encode function (threaded version).
+
+    This does some data setup, but works with a flat-packed version of
+    the input array.
+
+    Args:
+        flatdata (array):  The 1D reshaped view of the data.
+        n_stream (int64_t):  The number of streams.
+        stream_size (int64_t):  The length of each stream.
+        level (uint32_t):  The compression level (0-8).
+
+    Returns:
+        (tuple): The (compressed bytes, flat-packed starting bytes,
+            flat-packed stream bytes).
+
+    """
+    # Allocate the array of starts
+    cdef cnp.ndarray flat_starts = np.empty(n_stream, dtype=np.int64, order="C")
+    cdef cnp.ndarray flat_nbytes = np.empty(n_stream, dtype=np.int64, order="C")
+
+    cdef int64_t n_bytes
+    cdef unsigned char * rawbytes
+    cdef int errcode = 0
+
+    errcode = encode_i64_threaded(
+        <cnp.int64_t *>flatdata.data,
         n_stream,
         stream_size,
         level,
@@ -470,7 +536,7 @@ def encode_flac(data, int level, bool use_threads=False):
     subsets of streams within the larger compressed blob.
 
     Args:
-        data (numpy.ndarray):  The array of 32bit integers.
+        data (numpy.ndarray):  The array of 32bit or 64bit integers.
         level (int):  The FLAC compression level (0-8).
         use_threads (bool):  If True, use OpenMP threads to parallelize decoding.
             This is only beneficial for large arrays.
@@ -479,8 +545,8 @@ def encode_flac(data, int level, bool use_threads=False):
         (tuple):  The (compressed bytestream, stream starting bytes, stream nbytes).
 
     """
-    if data.dtype != flac_dtype:
-        msg = "Only 32bit integer data is supported"
+    if data.dtype != flac_i32_dtype and data.dtype != flac_i64_dtype:
+        msg = "Only 32bit or 64bit integer data is supported"
         raise RuntimeError(msg)
     if not data.data.c_contiguous:
         msg = "Only C-contiguous arrays are supported"
@@ -499,13 +565,23 @@ def encode_flac(data, int level, bool use_threads=False):
     flatdata = data.reshape((-1,))
 
     if use_threads:
-        compressed, flatstarts, flatnbytes = wrap_encode_threaded(
-            flatdata, n_stream, stream_size, level
-        )
+        if data.dtype == flac_i32_dtype:
+            compressed, flatstarts, flatnbytes = wrap_encode_i32_threaded(
+                flatdata, n_stream, stream_size, level
+            )
+        else:
+            compressed, flatstarts, flatnbytes = wrap_encode_i64_threaded(
+                flatdata, n_stream, stream_size, level
+            )
     else:
-        compressed, flatstarts, flatnbytes = wrap_encode(
-            flatdata, n_stream, stream_size, level
-        )
+        if data.dtype == flac_i32_dtype:
+            compressed, flatstarts, flatnbytes = wrap_encode_i32(
+                flatdata, n_stream, stream_size, level
+            )
+        else:
+            compressed, flatstarts, flatnbytes = wrap_encode_i64(
+                flatdata, n_stream, stream_size, level
+            )
 
     # Reshape and return
     return (
@@ -515,7 +591,7 @@ def encode_flac(data, int level, bool use_threads=False):
     )
 
 
-def wrap_decode(
+def wrap_decode_i32(
     cnp.ndarray[cnp.uint8_t, ndim=1, mode="c"] compressed,
     cnp.ndarray[cnp.int64_t, ndim=1, mode="c"] starts,
     cnp.ndarray[cnp.int64_t, ndim=1, mode="c"] nbytes,
@@ -525,7 +601,7 @@ def wrap_decode(
     cnp.int64_t last_sample,
     bool use_threads,
 ):
-    """Wrapper around the C decode function.
+    """Wrapper around the C int32 decode function.
 
     This works with flat-packed versions of the arrays.
 
@@ -552,10 +628,10 @@ def wrap_decode(
     cdef int64_t flat_size = n_stream * n_decode
 
     # Pre-allocate the output
-    cdef cnp.ndarray output = np.empty(flat_size, dtype=flac_dtype, order="C")
+    cdef cnp.ndarray output = np.empty(flat_size, dtype=flac_i32_dtype, order="C")
 
     cdef int errcode = 0
-    errcode = decode(
+    errcode = decode_i32(
         <cnp.uint8_t *>compressed.data,
         <cnp.int64_t *>starts.data,
         <cnp.int64_t *>nbytes.data,
@@ -571,9 +647,65 @@ def wrap_decode(
         # FIXME: change error codes so we can print a message here
         msg = f"Decoding failed, return code = {errcode}"
         raise RuntimeError(msg)
-
     return output
 
+def wrap_decode_i64(
+    cnp.ndarray[cnp.uint8_t, ndim=1, mode="c"] compressed,
+    cnp.ndarray[cnp.int64_t, ndim=1, mode="c"] starts,
+    cnp.ndarray[cnp.int64_t, ndim=1, mode="c"] nbytes,
+    cnp.int64_t n_stream,
+    cnp.int64_t stream_size,
+    cnp.int64_t first_sample,
+    cnp.int64_t last_sample,
+    bool use_threads,
+):
+    """Wrapper around the C int64 decode function.
+
+    This works with flat-packed versions of the arrays.
+
+    Args:
+        compressed (array):  The array of compressed bytes.
+        starts (array):  The array of starting bytes.
+        n_stream (int64_t):  The number of streams.
+        stream_size (int64_t):  The length of each stream.
+        first_sample (int64_t):  The first sample to decode.  Negative value indicates
+            this parameter is unused and the whole stream should be decoded.
+        last_sample (int64_t):  The last sample to decode (exclusive).  Negative value
+            indicates this parameter is unused and the whole stream should be decoded.
+        use_threads (bool):  If True, use OpenMP threads to parallelize decoding.
+            This is only beneficial for large arrays.
+
+    Returns:
+        (array):  The flat-packed int64 decompressed array.
+
+    """
+    cdef int64_t n_decode = stream_size
+    if first_sample >= 0 and last_sample >= 0:
+        n_decode = last_sample - first_sample
+
+    cdef int64_t flat_size = n_stream * n_decode
+
+    # Pre-allocate the output
+    cdef cnp.ndarray output = np.empty(flat_size, dtype=flac_i64_dtype, order="C")
+
+    cdef int errcode = 0
+    errcode = decode_i64(
+        <cnp.uint8_t *>compressed.data,
+        <cnp.int64_t *>starts.data,
+        <cnp.int64_t *>nbytes.data,
+        n_stream,
+        stream_size,
+        first_sample,
+        last_sample,
+        <cnp.int64_t *>output.data,
+        use_threads,
+    )
+
+    if errcode != 0:
+        # FIXME: change error codes so we can print a message here
+        msg = f"Decoding failed, return code = {errcode}"
+        raise RuntimeError(msg)
+    return output
 
 def decode_flac(
     compressed,
@@ -583,6 +715,7 @@ def decode_flac(
     int first_sample=-1,
     int last_sample=-1,
     bool use_threads=False,
+    bool is_int64=False,
 ):
     """Decompress a FLAC compressed bytestream.
 
@@ -603,9 +736,11 @@ def decode_flac(
             whole stream should be decoded.
         use_threads (bool):  If True, use OpenMP threads to parallelize decoding.
             This is only beneficial for large arrays.
+        is_int64 (bool):  If True, the compressed stream contains 64bit integers
+            encoded as 2 channels.
 
     Returns:
-        (array):  The decompressed array of int32 data.
+        (array):  The decompressed array of int32 or int64 data.
 
     """
     if compressed.dtype != compressed_dtype:
@@ -658,16 +793,28 @@ def decode_flac(
     flat_starts = starts.reshape((-1,))
     flat_nbytes = nbytes.reshape((-1,))
 
-    flat_output = wrap_decode(
-        compressed,
-        flat_starts,
-        flat_nbytes,
-        n_stream,
-        cstream_size,
-        cfirst_sample,
-        clast_sample,
-        use_threads,
-    )
+    if is_int64:
+        flat_output = wrap_decode_i64(
+            compressed,
+            flat_starts,
+            flat_nbytes,
+            n_stream,
+            cstream_size,
+            cfirst_sample,
+            clast_sample,
+            use_threads,
+        )
+    else:
+        flat_output = wrap_decode_i32(
+            compressed,
+            flat_starts,
+            flat_nbytes,
+            n_stream,
+            cstream_size,
+            cfirst_sample,
+            clast_sample,
+            use_threads,
+        )
 
     # Reshape and return
     return flat_output.reshape(output_shape)

--- a/src/flacarray/libflacarray/test_low_level.c
+++ b/src/flacarray/libflacarray/test_low_level.c
@@ -7,7 +7,10 @@
 
 #include "flacarray.h"
 
-int main(int argc, char *argv[]) {
+
+void test_32bit() {
+    fprintf(stderr, "============= 32bit Tests ===============\n");
+
     int64_t n_streams = 10;
     int64_t stream_len = 1000000;
     int64_t input_bytes = n_streams * stream_len * sizeof(int32_t);
@@ -55,7 +58,7 @@ int main(int argc, char *argv[]) {
     clock_t diff;
 
     // Encode to bytes
-    int status = encode(
+    int status = encode_i32(
         data,
         n_streams,
         stream_len,
@@ -75,7 +78,7 @@ int main(int argc, char *argv[]) {
     start = clock();
 
     // Encode to bytes
-    status = encode_threaded(
+    status = encode_i32_threaded(
         data,
         n_streams,
         stream_len,
@@ -106,7 +109,7 @@ int main(int argc, char *argv[]) {
     int64_t last_sample = -1;
 
     start = clock();
-    status = decode(
+    status = decode_i32(
         compressed,
         stream_starts,
         stream_nbytes,
@@ -123,7 +126,7 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "  CPU time:  %d seconds %d milliseconds\n", msec / 1000, msec % 1000);
 
     start = clock();
-    status = decode(
+    status = decode_i32(
         compressed,
         stream_starts,
         stream_nbytes,
@@ -172,7 +175,7 @@ int main(int argc, char *argv[]) {
     }
 
     start = clock();
-    status = decode(
+    status = decode_i32(
         compressed,
         stream_starts,
         stream_nbytes,
@@ -189,7 +192,7 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "  CPU time:  %d seconds %d milliseconds\n", msec / 1000, msec % 1000);
 
     start = clock();
-    status = decode(
+    status = decode_i32(
         compressed,
         stream_starts,
         stream_nbytes,
@@ -229,5 +232,249 @@ int main(int argc, char *argv[]) {
 
     free(data);
 
+    return;
+}
+
+
+void test_64bit() {
+    fprintf(stderr, "============= 64bit Tests ===============\n");
+
+    int64_t n_streams = 10;
+    int64_t stream_len = 1000000;
+    int64_t input_bytes = n_streams * stream_len * sizeof(int64_t);
+    uint32_t level = 5;
+
+    int64_t n_bytes;
+    uint8_t *compressed;
+    int64_t *stream_starts;
+    int64_t *stream_nbytes;
+
+    // Set up random number generator
+    int64_t n_state = 64;
+    char state[n_state];
+    char *previous_state = initstate(123456, state, n_state);
+    previous_state = setstate(state);
+
+    // Alloc input buffer
+    int64_t * data = (int64_t *)malloc(n_streams * stream_len * sizeof(int64_t));
+    if (data == NULL) {
+        fprintf(stderr, "Failed to allocate input data\n");
+    }
+
+    // Allocate the buffer of starts into the bytestream
+    stream_starts = (int64_t *)malloc(n_streams * sizeof(int64_t));
+    if (stream_starts == NULL) {
+        fprintf(stderr, "Failed to allocate starts\n");
+    }
+
+    // Allocate the buffer of bytes per stream
+    stream_nbytes = (int64_t *)malloc(n_streams * sizeof(int64_t));
+    if (stream_nbytes == NULL) {
+        fprintf(stderr, "Failed to allocate stream nbytes\n");
+    }
+
+    // Fill with randoms
+    long temp;
+    int32_t * view = (int32_t *)data;
+    for (int64_t istream = 0; istream < n_streams; ++istream) {
+        for (int64_t isamp = 0; isamp < stream_len; ++isamp) {
+            temp = random();
+            view[2 * (istream * stream_len + isamp)] = (int32_t)(temp);
+            temp = random();
+            view[2 * (istream * stream_len + isamp) + 1] = (int32_t)(temp);
+        }
+    }
+
+    clock_t start = clock();
+    clock_t diff;
+
+    // Encode to bytes
+    int status = encode_i64(
+        data,
+        n_streams,
+        stream_len,
+        level,
+        &n_bytes,
+        stream_starts,
+        &compressed);
+
+    diff = clock() - start;
+    int msec = diff * 1000 / CLOCKS_PER_SEC;
+
+    fprintf(stderr, "Encoded %ld streams of %ld 64bit integers (%ld bytes) into %ld bytes, status = %d\n", n_streams, stream_len, input_bytes, n_bytes, status);
+    fprintf(stderr, "  CPU time:  %d seconds %d milliseconds\n", msec / 1000, msec % 1000);
+
+    free(compressed);
+
+    start = clock();
+
+    // Encode to bytes
+    status = encode_i64_threaded(
+        data,
+        n_streams,
+        stream_len,
+        level,
+        &n_bytes,
+        stream_starts,
+        &compressed);
+
+    diff = clock() - start;
+    msec = diff * 1000 / CLOCKS_PER_SEC;
+
+    fprintf(stderr, "Encoded (threaded) %ld streams of %ld 64bit integers (%ld bytes) into %ld bytes, status = %d\n", n_streams, stream_len, input_bytes, n_bytes, status);
+    fprintf(stderr, "  CPU time:  %d seconds %d milliseconds\n", msec / 1000, msec % 1000);
+
+    // Compute stream nbytes
+    for (int64_t istream = 0; istream < n_streams - 1; ++istream) {
+        stream_nbytes[istream] = stream_starts[istream + 1] - stream_starts[istream];
+    }
+    stream_nbytes[n_streams - 1] = n_bytes - stream_starts[n_streams - 1];
+
+    int64_t * decompressed = (int64_t *)malloc(
+        n_streams * stream_len * sizeof(int64_t));
+    if (decompressed == NULL) {
+        fprintf(stderr, "Failed to allocate decompressed data\n");
+    }
+
+    int64_t first_sample = -1;
+    int64_t last_sample = -1;
+
+    start = clock();
+    status = decode_i64(
+        compressed,
+        stream_starts,
+        stream_nbytes,
+        n_streams,
+        stream_len,
+        first_sample,
+        last_sample,
+        decompressed,
+        false);
+    diff = clock() - start;
+    msec = diff * 1000 / CLOCKS_PER_SEC;
+
+    fprintf(stderr, "Decoded %ld streams of %ld 64bit integers, status = %d\n", n_streams, stream_len, status);
+    fprintf(stderr, "  CPU time:  %d seconds %d milliseconds\n", msec / 1000, msec % 1000);
+
+    start = clock();
+    status = decode_i64(
+        compressed,
+        stream_starts,
+        stream_nbytes,
+        n_streams,
+        stream_len,
+        first_sample,
+        last_sample,
+        decompressed,
+        true);
+    diff = clock() - start;
+    msec = diff * 1000 / CLOCKS_PER_SEC;
+
+    fprintf(stderr, "Decoded (with threads) %ld streams of %ld 64bit integers, status = %d\n", n_streams, stream_len, status);
+    fprintf(stderr, "  CPU time:  %d seconds %d milliseconds\n", msec / 1000, msec % 1000);
+
+    // Verify
+    int64_t elem;
+    int32_t * in_view = (int32_t *)data;
+    int32_t * out_view = (int32_t *)decompressed;
+    for (int64_t istream = 0; istream < n_streams; ++istream) {
+        for (int64_t isamp = 0; isamp < stream_len; ++isamp) {
+            elem = istream * stream_len + isamp;
+            if (data[elem] != decompressed[elem]) {
+                fprintf(stderr,
+                    "FAIL stream %ld, sample %ld:  %ld != %ld\n",
+                    istream, isamp, decompressed[elem], data[elem]);
+                fprintf(stderr,
+                    "          out [ %d | %d ] != in [ %d | %d ]\n",
+                    out_view[2*elem], out_view[2*elem+1],
+                    in_view[2*elem], in_view[2*elem+1]);
+            }
+        }
+    }
+    fprintf(stderr, "SUCCESS\n");
+
+    free(decompressed);
+
+    // Now try decoding a slice
+
+    first_sample = (int64_t)(stream_len / 2) - 5;
+    last_sample = (int64_t)(stream_len / 2) + 5;
+
+    first_sample = 1;
+    last_sample = 6;
+
+    int64_t n_decode = last_sample - first_sample;
+
+    decompressed = (int64_t *)malloc(
+        n_streams * n_decode * sizeof(int64_t));
+    if (decompressed == NULL) {
+        fprintf(stderr, "Failed to allocate decompressed data\n");
+    }
+
+    start = clock();
+    status = decode_i64(
+        compressed,
+        stream_starts,
+        stream_nbytes,
+        n_streams,
+        stream_len,
+        first_sample,
+        last_sample,
+        decompressed,
+        false);
+    diff = clock() - start;
+    msec = diff * 1000 / CLOCKS_PER_SEC;
+
+    fprintf(stderr, "Decoded %ld streams with slice of %ld 64bit integers, status = %d\n", n_streams, n_decode, status);
+    fprintf(stderr, "  CPU time:  %d seconds %d milliseconds\n", msec / 1000, msec % 1000);
+
+    start = clock();
+    status = decode_i64(
+        compressed,
+        stream_starts,
+        stream_nbytes,
+        n_streams,
+        stream_len,
+        first_sample,
+        last_sample,
+        decompressed,
+        true);
+    diff = clock() - start;
+    msec = diff * 1000 / CLOCKS_PER_SEC;
+
+    fprintf(stderr, "Decoded (with threads) %ld streams with slice of %ld 64bit integers, status = %d\n", n_streams, n_decode, status);
+    fprintf(stderr, "  CPU time:  %d seconds %d milliseconds\n", msec / 1000, msec % 1000);
+
+    // Verify
+    int64_t input_elem;
+    int64_t output_elem;
+    for (int64_t istream = 0; istream < n_streams; ++istream) {
+        for (int64_t isamp = first_sample; isamp < last_sample; ++isamp) {
+            input_elem = istream * stream_len + isamp;
+            output_elem = istream * n_decode + (isamp - first_sample);
+            if (data[input_elem] != decompressed[output_elem]) {
+                fprintf(stderr,
+                    "FAIL stream %ld, sample %ld:  %ld != %ld\n",
+                    istream, isamp, decompressed[output_elem], data[input_elem]);
+            }
+        }
+    }
+    fprintf(stderr, "SUCCESS\n");
+
+    free(decompressed);
+
+    free(compressed);
+    free(stream_starts);
+    free(stream_nbytes);
+
+    free(data);
+
+    return;
+}
+
+
+int main(int argc, char *argv[]) {
+    test_32bit();
+    test_64bit();
     return 0;
 }

--- a/src/flacarray/libflacarray/utils.c
+++ b/src/flacarray/libflacarray/utils.c
@@ -3,6 +3,7 @@
 // a BSD-style license that can be found in the LICENSE file.
 
 #include "flacarray.h"
+#include <stdio.h>
 
 
 ArrayUint8 * create_array_uint8(int64_t start_size) {
@@ -75,119 +76,79 @@ int resize_array_uint8(ArrayUint8 * obj, int64_t new_size) {
     return ERROR_NONE;
 }
 
-ArrayInt32 * create_array_int32(int64_t start_size) {
-    ArrayInt32 * ret = (ArrayInt32 *)malloc(sizeof(ArrayInt32));
-    if (ret == NULL) {
-        return NULL;
+// Check if the current machine is little endian.
+bool is_little_endian() {
+    int test = 1;
+    if (*((char *)(&test)) == 1) {
+        return true;
+    } else {
+        return false;
     }
-    (*ret).size = 0;
-    (*ret).n_elem = 0;
-    (*ret).data = NULL;
-    if (start_size > 0) {
-        resize_array_int32(ret, start_size);
-    }
-    return ret;
 }
 
-void destroy_array_int32(ArrayInt32 * obj) {
-    if (obj != NULL) {
-        if (obj->data != NULL) {
-            free(obj->data);
+// Union used to unpack the high and low 32bits from a
+// big endian int64.  Note that the FLAC library itself already
+// handles endian conversion within each 32bit value, so we don't
+// need to do any byte-swapping here.  We are just ensuring that
+// the two channels represent the same things (high and low order
+// 32bits) across architectures.
+typedef union {
+    int64_t value;
+    struct {
+        int32_t high, low;
+    };
+} int64_hilow;
+
+// If necessary (on big-endian systems), allocate a 32bit buffer
+// and fill with swapped interleaved values so that the first channel
+// is always the lower-order 32bit value.
+int get_interleaved(int64_t n_elem, int64_t const * data, int32_t ** interleaved) {
+    if (is_little_endian()) {
+        // No separate memory buffer needed
+        (*interleaved) = (int32_t *)data;
+    } else {
+        // Have to allocate a buffer to hold the swapped values.
+        (*interleaved) = (int32_t *)malloc(2 * n_elem * sizeof(int32_t));
+        if ((*interleaved) == NULL) {
+            // Allocation failed
+            return ERROR_ALLOC;
         }
-        free(obj);
+    }
+    return ERROR_NONE;
+}
+
+// Copy data to / from interleaved format
+
+void copy_interleaved_64_to_32(int64_t n_elem, int64_t * input, int32_t * output) {
+    int64_hilow * view = (int64_hilow *)input;
+    if (! is_little_endian()) {
+        for (int64_t i = 0; i < n_elem; ++i) {
+            output[2 * i] = view[i].low;
+            output[2 * i + 1] = view[i].high;
+        }
     }
     return;
 }
 
-int resize_array_int32(ArrayInt32 * obj, int64_t new_size) {
-    int64_t try_size;
-    int32_t * temp_ptr;
-    if (obj != NULL) {
-        if (obj->data == NULL) {
-            // Not yet allocated
-            obj->data = (int32_t *)malloc(new_size * sizeof(int32_t));
-            if (obj->data == NULL) {
-                // Allocation failed, set size to zero.
-                obj->size = 0;
-                obj->n_elem = 0;
-            } else {
-                // Allocation worked.
-                obj->size = new_size;
-                obj->n_elem = new_size;
-            }
-        } else {
-            // Data already allocated, check current size
-            if (obj->size >= new_size) {
-                // We already have enough space
-                obj->n_elem = new_size;
-            } else {
-                // We need to re-allocate.  Grow our size exponentially
-                // to reduce the number of future allocations.
-                try_size = obj->size;
-                while (try_size < new_size) {
-                    try_size *= 2;
-                }
-                temp_ptr = (int32_t *)realloc(
-                    (void*)(obj->data),
-                    try_size * sizeof(int32_t)
-                );
-                if (temp_ptr != NULL) {
-                    // Realloc success
-                    obj->data = temp_ptr;
-                    obj->size = try_size;
-                    obj->n_elem = new_size;
-                }
-            }
-        }
-    } else {
-        return ERROR_ALLOC;
-    }
-    return ERROR_NONE;
-}
-
-
-int int64_to_int32(
-    int64_t const * input,
-    int64_t n_stream,
-    int64_t stream_size,
-    int32_t * output,
-    int64_t * offsets
-) {
-    // FLAC uses an extra bit, so +/- 2^30 is the max range.
-    int64_t flac_max = 1073741824;
-
-    int64_t smin;
-    int64_t smax;
-    int64_t sindx;
-    int64_t sval;
-    int64_t stemp;
-    for (int64_t istream = 0; istream < n_stream; ++istream) {
-        smin = input[istream * stream_size];
-        smax = input[istream * stream_size];
-        for (int64_t isamp = 1; isamp < stream_size; ++isamp) {
-            sindx = istream * stream_size + isamp;
-            sval = input[sindx];
-            if (sval < smin) {
-                smin = sval;
-            }
-            if (sval > smax) {
-                smax = sval;
-            }
-        }
-        offsets[istream] = (int64_t)((0.5 * (double)(smin + smax)) + 0.5);
-        for (int64_t isamp = 0; isamp < stream_size; ++isamp) {
-            sindx = istream * stream_size + isamp;
-            stemp = input[sindx] - offsets[istream];
-            if ((stemp > flac_max) || (stemp < -flac_max)) {
-                return ERROR_CONVERT_TYPE;
-            } else {
-                output[sindx] = (int32_t)stemp;
-            }
+void copy_interleaved_32_to_64(int64_t n_elem, int32_t * input, int64_t * output) {
+    int64_hilow * view = (int64_hilow *)output;
+    if (! is_little_endian()) {
+        for (int64_t i = 0; i < n_elem; ++i) {
+            view[i].low = input[2 * i];
+            view[i].high = input[2 * i + 1];
         }
     }
-    return ERROR_NONE;
+    return;
 }
 
+// If the interleaved buffer was previously allocated, free it.
+void free_interleaved(int32_t * interleaved) {
+    if (! is_little_endian()) {
+        // Free buffer
+        free(interleaved);
+    }
+    return;
+}
 
 int float32_to_int32(
     float const * input,
@@ -265,18 +226,19 @@ int float32_to_int32(
     return ERROR_NONE;
 }
 
-
-int float64_to_int32(
+int float64_to_int64(
     double const * input,
     int64_t n_stream,
     int64_t stream_size,
     double const * quanta,
-    int32_t * output,
+    int64_t * output,
     double * offsets,
     double * gains
 ) {
-    // FLAC uses an extra bit, so +/- 2^30 is the max range.
-    int64_t flac_max = 1073741824;
+    // FLAC uses an extra bit, so +/- 2^62 is the max range.
+    uint64_t zero = 0;
+    uint64_t all_ones = ~(zero);
+    int64_t flac_max = (int64_t)(all_ones >> 2);
 
     double smin;
     double smax;
@@ -336,33 +298,14 @@ int float64_to_int32(
         for (int64_t isamp = 0; isamp < stream_size; ++isamp) {
             sindx = istream * stream_size + isamp;
             stemp = input[sindx] - offsets[istream];
-            output[sindx] = (int32_t)(gains[istream] * stemp + 0.5);
+            output[sindx] = (int64_t)(gains[istream] * stemp + 0.5);
         }
     }
     return ERROR_NONE;
 }
 
-
-void int32_to_int64(
-    int32_t const * input,
-    int64_t n_stream,
-    int64_t stream_size,
-    int64_t const * offsets,
-    int64_t * output
-) {
-    int64_t sindx;
-    for (int64_t istream = 0; istream < n_stream; ++istream) {
-        for (int64_t isamp = 0; isamp < stream_size; ++isamp) {
-            sindx = istream * stream_size + isamp;
-            output[sindx] = offsets[istream] + (int64_t)input[sindx];
-        }
-    }
-    return;
-}
-
-
-void int32_to_float64(
-    int32_t const * input,
+void int64_to_float64(
+    int64_t const * input,
     int64_t n_stream,
     int64_t stream_size,
     double const * offsets,
@@ -380,7 +323,6 @@ void int32_to_float64(
     }
     return;
 }
-
 
 void int32_to_float32(
     int32_t const * input,

--- a/src/flacarray/meson.build
+++ b/src/flacarray/meson.build
@@ -8,10 +8,12 @@ python_sources = [
     'hdf5.py',
     'hdf5_utils.py',
     'hdf5_load_v0.py',
+    'hdf5_load_v1.py',
     'mpi.py',
     'demo.py',
     'zarr.py',
     'zarr_load_v0.py',
+    'zarr_load_v1.py',
     'io_common.py',
 ]
 

--- a/src/flacarray/tests/array.py
+++ b/src/flacarray/tests/array.py
@@ -35,7 +35,9 @@ class ArrayTest(unittest.TestCase):
             .astype(np.int32)
         )
 
-        comp_i32, starts_i32, nbytes_i32, off_i32, gain_i32 = array_compress(data_i32, level=5)
+        comp_i32, starts_i32, nbytes_i32, off_i32, gain_i32 = array_compress(
+            data_i32, level=5
+        )
         self.assertTrue(off_i32 is None)
         self.assertTrue(gain_i32 is None)
 
@@ -52,18 +54,20 @@ class ArrayTest(unittest.TestCase):
         )
         self.assertTrue(np.array_equal(check_slc_i32, data_i32[:, :, first:last]))
 
-        # int64 data.  First try a case that should work, with all values inside
-        # the 32bit range.
+        # int64 data.
 
         data_i64 = rng.integers(
-            low=-(2**30), high=2**29, size=flatsize, dtype=np.int64
+            low=-(2**60), high=2**62, size=flatsize, dtype=np.int64
         ).reshape(data_shape)
 
-        comp_i64, starts_i64, nbytes_i64, off_i64, gain_i64 = array_compress(data_i64, level=5)
+        comp_i64, starts_i64, nbytes_i64, off_i64, gain_i64 = array_compress(
+            data_i64, level=5
+        )
+        self.assertTrue(off_i64 is None)
         self.assertTrue(gain_i64 is None)
 
         check_i64 = array_decompress(
-            comp_i64, data_shape[-1], starts_i64, nbytes_i64, stream_offsets=off_i64
+            comp_i64, data_shape[-1], starts_i64, nbytes_i64, is_int64=True
         )
         self.assertTrue(np.array_equal(check_i64, data_i64))
 
@@ -72,29 +76,18 @@ class ArrayTest(unittest.TestCase):
             data_shape[-1],
             starts_i64,
             nbytes_i64,
-            stream_offsets=off_i64,
             first_stream_sample=first,
             last_stream_sample=last,
+            is_int64=True,
         )
         self.assertTrue(np.array_equal(check_slc_i64, data_i64[:, :, first:last]))
-
-        # Now try a case that should NOT work.
-
-        data_i64 = rng.integers(
-            low=-(2**60), high=2**62, size=flatsize, dtype=np.int64
-        ).reshape(data_shape)
-
-        try:
-            comp_i64, starts_i64, nbytes_i64, off_i64, gain_i64 = array_compress(data_i64, level=5)
-            print("Failed to catch truncation of int64 data")
-            self.assertTrue(False)
-        except RuntimeError:
-            pass
 
         # float32 data
 
         data_f32 = create_fake_data(data_shape, 1.0).astype(np.float32)
-        comp_f32, starts_f32, nbytes_f32, off_f32, gain_f32 = array_compress(data_f32, level=5)
+        comp_f32, starts_f32, nbytes_f32, off_f32, gain_f32 = array_compress(
+            data_f32, level=5
+        )
         check_f32 = array_decompress(
             comp_f32,
             data_shape[-1],
@@ -123,7 +116,9 @@ class ArrayTest(unittest.TestCase):
 
         data_f64 = create_fake_data(data_shape, 1.0)
 
-        comp_f64, starts_f64, nbytes_f64, off_f64, gain_f64 = array_compress(data_f64, level=5)
+        comp_f64, starts_f64, nbytes_f64, off_f64, gain_f64 = array_compress(
+            data_f64, level=5
+        )
         check_f64 = array_decompress(
             comp_f64,
             data_shape[-1],
@@ -131,8 +126,9 @@ class ArrayTest(unittest.TestCase):
             nbytes_f64,
             stream_offsets=off_f64,
             stream_gains=gain_f64,
+            is_int64=True,
         )
-        self.assertTrue(np.allclose(check_f64, data_f64, rtol=1e-5, atol=1e-5))
+        self.assertTrue(np.allclose(check_f64, data_f64, rtol=1e-15, atol=1e-15))
 
         check_slc_f64 = array_decompress(
             comp_f64,
@@ -143,9 +139,12 @@ class ArrayTest(unittest.TestCase):
             stream_gains=gain_f64,
             first_stream_sample=first,
             last_stream_sample=last,
+            is_int64=True,
         )
         self.assertTrue(
-            np.allclose(check_slc_f64, data_f64[:, :, first:last], rtol=1e-5, atol=1e-5)
+            np.allclose(
+                check_slc_f64, data_f64[:, :, first:last], rtol=1e-15, atol=1e-15
+            )
         )
 
     def test_array_memory(self):
@@ -157,9 +156,11 @@ class ArrayTest(unittest.TestCase):
 
         farray = FlacArray.from_array(data_f64)
         check_f64 = farray.to_array()
-        self.assertTrue(np.allclose(check_f64, data_f64, rtol=1e-5, atol=1e-5))
+        self.assertTrue(np.allclose(check_f64, data_f64, rtol=1e-15, atol=1e-15))
 
         check_slc_f64 = farray.to_array(stream_slice=slice(first, last, 1))
         self.assertTrue(
-            np.allclose(check_slc_f64, data_f64[:, :, first:last], rtol=1e-5, atol=1e-5)
+            np.allclose(
+                check_slc_f64, data_f64[:, :, first:last], rtol=1e-15, atol=1e-15
+            )
         )

--- a/src/flacarray/tests/bindings.py
+++ b/src/flacarray/tests/bindings.py
@@ -8,9 +8,12 @@ import unittest
 import numpy as np
 
 from ..libflacarray import (
-    wrap_encode,
-    wrap_encode_threaded,
-    wrap_decode,
+    wrap_encode_i32,
+    wrap_encode_i32_threaded,
+    wrap_encode_i64,
+    wrap_encode_i64_threaded,
+    wrap_decode_i32,
+    wrap_decode_i64,
     encode_flac,
     decode_flac,
 )
@@ -20,7 +23,7 @@ class BindingsTest(unittest.TestCase):
     def setUp(self):
         fixture_name = os.path.splitext(os.path.basename(__file__))[0]
 
-    def test_wrappers(self):
+    def test_wrappers_i32(self):
         n_streams = 3
         stream_len = 10000
         level = 5
@@ -28,14 +31,21 @@ class BindingsTest(unittest.TestCase):
         flatsize = n_streams * stream_len
 
         rng = np.random.default_rng()
-        data = rng.integers(low=-2 * 28, high=2 * 28, size=flatsize, dtype=np.int32)
+        data = rng.integers(low=-(2**28), high=2**28, size=flatsize, dtype=np.int32)
 
-        compressed, stream_starts, stream_nbytes = wrap_encode_threaded(
+        compressed, stream_starts, stream_nbytes = wrap_encode_i32_threaded(
             data, n_streams, stream_len, level
         )
 
-        output = wrap_decode(
-            compressed, stream_starts, stream_nbytes, n_streams, stream_len, -1, -1, True
+        output = wrap_decode_i32(
+            compressed,
+            stream_starts,
+            stream_nbytes,
+            n_streams,
+            stream_len,
+            -1,
+            -1,
+            True,
         )
 
         for istream in range(n_streams):
@@ -55,8 +65,15 @@ class BindingsTest(unittest.TestCase):
         last = (stream_len // 2) + 5
         n_decode = last - first
 
-        output_slc = wrap_decode(
-            compressed, stream_starts, stream_nbytes, n_streams, stream_len, first, last, True
+        output_slc = wrap_decode_i32(
+            compressed,
+            stream_starts,
+            stream_nbytes,
+            n_streams,
+            stream_len,
+            first,
+            last,
+            True,
         )
         for istream in range(n_streams):
             for isamp in range(n_decode):
@@ -70,7 +87,71 @@ class BindingsTest(unittest.TestCase):
                     print(msg)
                     self.assertTrue(False)
 
-    def test_roundtrip(self):
+    def test_wrappers_i64(self):
+        n_streams = 3
+        stream_len = 10000
+        level = 5
+
+        flatsize = n_streams * stream_len
+
+        rng = np.random.default_rng()
+        data = rng.integers(low=-(2**60), high=2**60, size=flatsize, dtype=np.int64)
+
+        compressed, stream_starts, stream_nbytes = wrap_encode_i64_threaded(
+            data, n_streams, stream_len, level
+        )
+
+        output = wrap_decode_i64(
+            compressed,
+            stream_starts,
+            stream_nbytes,
+            n_streams,
+            stream_len,
+            -1,
+            -1,
+            True,
+        )
+
+        for istream in range(n_streams):
+            for isamp in range(stream_len):
+                if (
+                    output[istream * stream_len + isamp]
+                    != data[istream * stream_len + isamp]
+                ):
+                    msg = f"FAIL [{istream},{isamp}]: "
+                    msg += f"{output[istream * stream_len + isamp]} "
+                    msg += f"!= {data[istream * stream_len + isamp]}"
+                    print(msg)
+                    self.assertTrue(False)
+
+        # Now testing with sample slices
+        first = (stream_len // 2) - 5
+        last = (stream_len // 2) + 5
+        n_decode = last - first
+
+        output_slc = wrap_decode_i64(
+            compressed,
+            stream_starts,
+            stream_nbytes,
+            n_streams,
+            stream_len,
+            first,
+            last,
+            True,
+        )
+        for istream in range(n_streams):
+            for isamp in range(n_decode):
+                if (
+                    output_slc[istream * n_decode + isamp]
+                    != data[istream * stream_len + isamp + first]
+                ):
+                    msg = f"FAIL [{istream},{isamp}]: "
+                    msg += f"{output_slc[istream * n_decode + isamp]} "
+                    msg += f"!= {data[istream * stream_len + isamp + first]}"
+                    print(msg)
+                    self.assertTrue(False)
+
+    def test_roundtrip_i32(self):
         n_streams = 3
         stream_len = 10000
         level = 5
@@ -82,9 +163,46 @@ class BindingsTest(unittest.TestCase):
             low=-(2**28), high=2**28, size=flatsize, dtype=np.int32
         ).reshape((n_streams, stream_len))
 
-        (compressed, stream_starts, stream_nbytes) = encode_flac(data, level, use_threads=True)
+        (compressed, stream_starts, stream_nbytes) = encode_flac(
+            data, level, use_threads=True
+        )
 
-        output = decode_flac(compressed, stream_starts, stream_nbytes, stream_len, use_threads=True)
+        output = decode_flac(
+            compressed, stream_starts, stream_nbytes, stream_len, use_threads=True
+        )
+
+        for istream in range(n_streams):
+            for isamp in range(stream_len):
+                if output[istream, isamp] != data[istream, isamp]:
+                    msg = f"FAIL [{istream},{isamp}]: {output[istream, isamp]} "
+                    msg += f"!= {data[istream, isamp]}"
+                    print(msg)
+                    self.assertTrue(False)
+
+    def test_roundtrip_i64(self):
+        n_streams = 3
+        stream_len = 10000
+        level = 5
+
+        flatsize = n_streams * stream_len
+
+        rng = np.random.default_rng()
+        data = rng.integers(
+            low=-(2**60), high=2**60, size=flatsize, dtype=np.int64
+        ).reshape((n_streams, stream_len))
+
+        (compressed, stream_starts, stream_nbytes) = encode_flac(
+            data, level, use_threads=True
+        )
+
+        output = decode_flac(
+            compressed,
+            stream_starts,
+            stream_nbytes,
+            stream_len,
+            use_threads=True,
+            is_int64=True,
+        )
 
         for istream in range(n_streams):
             for isamp in range(stream_len):

--- a/src/flacarray/tests/utils.py
+++ b/src/flacarray/tests/utils.py
@@ -10,9 +10,8 @@ import numpy as np
 from ..demo import create_fake_data
 
 from ..utils import (
-    int64_to_int32,
-    int32_to_float,
-    float_to_int32,
+    int_to_float,
+    float_to_int,
 )
 
 
@@ -20,71 +19,44 @@ class UtilsTest(unittest.TestCase):
     def setUp(self):
         fixture_name = os.path.splitext(os.path.basename(__file__))[0]
 
-    def test_int64(self):
-        data_shape = (4, 3, 1000)
-        leading_shape = data_shape[:-1]
-        flatsize = np.prod(data_shape)
-        rng = np.random.default_rng()
-
-        input32 = (
-            rng.integers(low=-(2**27), high=2**30, size=flatsize, dtype=np.int32)
-            .reshape(data_shape)
-            .astype(np.int64)
-        )
-        input64 = rng.integers(
-            low=-(2**60), high=2**62, size=flatsize, dtype=np.int64
-        ).reshape(data_shape)
-
-        idata, ioff = int64_to_int32(input32)
-        check = idata + ioff.reshape(leading_shape + (1,))
-        self.assertTrue(np.array_equal(check, input32))
-
-        # Check that we get an error for large integer truncation
-        try:
-            idata, ioff = int64_to_int32(input64)
-            print("Failed to catch 64bit integer truncation")
-            self.assertTrue(False)
-        except RuntimeError:
-            pass
-
     def test_float64(self):
         data_shape = (4, 3, 1000)
         data = create_fake_data(data_shape, 1.0)
 
-        idata, offsets, gains = float_to_int32(data, quanta=None, precision=None)
-        check = int32_to_float(idata, offsets, gains)
-        if not np.allclose(check, data, rtol=1e-5, atol=1e-5):
+        idata, offsets, gains = float_to_int(data, quanta=None, precision=None)
+        check = int_to_float(idata, offsets, gains)
+        if not np.allclose(check, data, rtol=1e-15, atol=1e-15):
             print("Failed float64 roundtrip")
             print(f"{check} != {data}", flush=True)
             self.assertTrue(False)
 
         prec = 5
-        idata, offsets, gains = float_to_int32(data, quanta=None, precision=prec)
-        check = int32_to_float(idata, offsets, gains)
+        idata, offsets, gains = float_to_int(data, quanta=None, precision=prec)
+        check = int_to_float(idata, offsets, gains)
         if not np.allclose(check, data, rtol=1e-5, atol=1e-4):
             print("Failed float64 precision roundtrip")
             print(f"{check} != {data}", flush=True)
             self.assertTrue(False)
-        idata, offsets, gains = float_to_int32(
+        idata, offsets, gains = float_to_int(
             data, quanta=None, precision=prec * np.ones(data_shape[:-1])
         )
-        check = int32_to_float(idata, offsets, gains)
+        check = int_to_float(idata, offsets, gains)
         if not np.allclose(check, data, rtol=1e-5, atol=1e-4):
             print("Failed float64 precision roundtrip")
             print(f"{check} != {data}", flush=True)
             self.assertTrue(False)
 
         quant = 1e-5
-        idata, offsets, gains = float_to_int32(data, quanta=quant, precision=None)
-        check = int32_to_float(idata, offsets, gains)
+        idata, offsets, gains = float_to_int(data, quanta=quant, precision=None)
+        check = int_to_float(idata, offsets, gains)
         if not np.allclose(check, data, rtol=1e-5, atol=1e-4):
             print("Failed float64 quanta roundtrip")
             print(f"{check} != {data}", flush=True)
             self.assertTrue(False)
-        idata, offsets, gains = float_to_int32(
+        idata, offsets, gains = float_to_int(
             data, quanta=quant * np.ones(data_shape[:-1]), precision=None
         )
-        check = int32_to_float(idata, offsets, gains)
+        check = int_to_float(idata, offsets, gains)
         if not np.allclose(check, data, rtol=1e-5, atol=1e-4):
             print("Failed float64 quanta roundtrip")
             print(f"{check} != {data}", flush=True)
@@ -93,40 +65,40 @@ class UtilsTest(unittest.TestCase):
     def test_float32(self):
         data_shape = (4, 3, 1000)
         data = create_fake_data(data_shape, 1.0).astype(np.float32)
-        idata, offsets, gains = float_to_int32(data, quanta=None, precision=None)
-        check = int32_to_float(idata, offsets, gains)
+        idata, offsets, gains = float_to_int(data, quanta=None, precision=None)
+        check = int_to_float(idata, offsets, gains)
         if not np.allclose(check, data, rtol=1e-5, atol=1e-5):
             print("Failed float32 roundtrip")
             print(f"{check} != {data}", flush=True)
             self.assertTrue(False)
 
         prec = 5
-        idata, offsets, gains = float_to_int32(data, quanta=None, precision=prec)
-        check = int32_to_float(idata, offsets, gains)
+        idata, offsets, gains = float_to_int(data, quanta=None, precision=prec)
+        check = int_to_float(idata, offsets, gains)
         if not np.allclose(check, data, rtol=1e-5, atol=1e-4):
             print("Failed float32 precision roundtrip")
             print(f"{check} != {data}", flush=True)
             self.assertTrue(False)
-        idata, offsets, gains = float_to_int32(
+        idata, offsets, gains = float_to_int(
             data, quanta=None, precision=prec * np.ones(data_shape[:-1])
         )
-        check = int32_to_float(idata, offsets, gains)
+        check = int_to_float(idata, offsets, gains)
         if not np.allclose(check, data, rtol=1e-5, atol=1e-4):
             print("Failed float32 precision roundtrip")
             print(f"{check} != {data}", flush=True)
             self.assertTrue(False)
 
         quant = 1e-5
-        idata, offsets, gains = float_to_int32(data, quanta=quant, precision=None)
-        check = int32_to_float(idata, offsets, gains)
+        idata, offsets, gains = float_to_int(data, quanta=quant, precision=None)
+        check = int_to_float(idata, offsets, gains)
         if not np.allclose(check, data, rtol=1e-5, atol=1e-4):
             print("Failed float32 quanta roundtrip")
             print(f"{check} != {data}", flush=True)
             self.assertTrue(False)
-        idata, offsets, gains = float_to_int32(
+        idata, offsets, gains = float_to_int(
             data, quanta=quant * np.ones(data_shape[:-1]), precision=None
         )
-        check = int32_to_float(idata, offsets, gains)
+        check = int_to_float(idata, offsets, gains)
         if not np.allclose(check, data, rtol=1e-5, atol=1e-4):
             print("Failed float32 quanta roundtrip")
             print(f"{check} != {data}", flush=True)

--- a/src/flacarray/utils.py
+++ b/src/flacarray/utils.py
@@ -11,12 +11,10 @@ from functools import wraps
 import numpy as np
 
 from .libflacarray import (
-    wrap_int64_to_int32,
     wrap_float32_to_int32,
-    wrap_float64_to_int32,
-    wrap_int32_to_int64,
+    wrap_float64_to_int64,
     wrap_int32_to_float32,
-    wrap_int32_to_float64,
+    wrap_int64_to_float64,
 )
 
 
@@ -178,52 +176,12 @@ def function_timer_stackskip(f):
 
 
 @function_timer
-def int64_to_int32(data):
-    """Convert an array of 64bit integer streams to 32bit.
-
-    For each stream, this finds the 64bit integer mean and subtracts it.  It then
-    checks that the stream values will fit in a 32bit integer representation.  If you
-    want to treat the integer values as floating point data, use float_to_int32
-    instead.
-
-    The offset array returned will have the same shape as the leading dimensions of
-    the input array.
-
-    Args:
-        data (array):  The 64bit integer array.
-
-    Returns:
-        (tuple):  The (integer data, offset array)
-
-    """
-    if data.dtype != np.dtype(np.int64):
-        raise ValueError("Only int64 data is supported by this function")
-
-    leading_shape = data.shape[:-1]
-    if len(leading_shape) == 0:
-        n_stream = 1
-    else:
-        n_stream = np.prod(leading_shape)
-    stream_size = data.shape[-1]
-
-    output, offsets = wrap_int64_to_int32(
-        data.reshape((-1,)),
-        n_stream,
-        stream_size,
-    )
-
-    return (
-        output.reshape(data.shape),
-        offsets.reshape(leading_shape),
-    )
-
-
-@function_timer
-def float_to_int32(data, quanta=None, precision=None):
+def float_to_int(data, quanta=None, precision=None):
     """Convert floating point data to integers.
 
     This function subtracts the mean and rescales data before rounding to 32bit
-    integer values.
+    or 64bit integer values.  32bit floats are converted to 32bit integers and
+    64bit floats are converted to 64bit integers.
 
     Args:
         data (array):  The floating point data.
@@ -281,7 +239,7 @@ def float_to_int32(data, quanta=None, precision=None):
             quanta.reshape((-1,)).astype(data.dtype),
         )
     else:
-        output, offsets, gains = wrap_float64_to_int32(
+        output, offsets, gains = wrap_float64_to_int64(
             data.reshape((-1,)),
             n_stream,
             stream_size,
@@ -296,13 +254,15 @@ def float_to_int32(data, quanta=None, precision=None):
 
 
 @function_timer
-def int32_to_float(idata, offset, gain):
+def int_to_float(idata, offset, gain):
     """Restore floating point data from integers.
 
     The gain and offset are applied and the resulting data is returned.
+    32bit integer data is converted to 32bit floats and 64bit integer data
+    is converted to 64bit floats.
 
     Args:
-        idata (array):  The 32bit integer data.
+        idata (array):  The 32bit or 64bit integer data.
         offset (array):  The offset used in the original conversion.
         gain (array):  The gain used in the original conversion.
 
@@ -310,8 +270,8 @@ def int32_to_float(idata, offset, gain):
         (array):  The restored float data.
 
     """
-    if idata.dtype != np.dtype(np.int32):
-        raise ValueError("Input data should be int32")
+    if idata.dtype != np.dtype(np.int32) and idata.dtype != np.dtype(np.int64):
+        raise ValueError("Input data should be int32 or int64")
 
     leading_shape = idata.shape[:-1]
     if len(leading_shape) == 0:
@@ -328,7 +288,7 @@ def int32_to_float(idata, offset, gain):
         msg = f"Gain array has shape {gain.shape}, expected shape {leading_shape}"
         raise ValueError(msg)
 
-    if gain.dtype == np.dtype(np.float32):
+    if idata.dtype == np.dtype(np.int32):
         result = wrap_int32_to_float32(
             idata.reshape((-1,)),
             n_stream,
@@ -337,7 +297,7 @@ def int32_to_float(idata, offset, gain):
             gain.reshape((-1,)),
         )
     else:
-        result = wrap_int32_to_float64(
+        result = wrap_int64_to_float64(
             idata.reshape((-1,)),
             n_stream,
             stream_size,

--- a/src/flacarray/zarr.py
+++ b/src/flacarray/zarr.py
@@ -153,6 +153,7 @@ def write_compressed(
     stream_offsets,
     stream_gains,
     compressed,
+    n_channels,
     local_nbytes,
     global_nbytes,
     global_process_nbytes,
@@ -179,9 +180,10 @@ def write_compressed(
         stream_starts (array):  The local starting byte offsets for each stream.
         global_stream_starts (array):  The global starting byte offsets for each stream.
         stream_nbytes (array):  The local number of bytes for each stream.
-        stream_offsets (array):  The offsets used in int32 conversion.
-        stream_gains (array):  The gains used in int32 conversion.
+        stream_offsets (array):  The offsets used in int conversion.
+        stream_gains (array):  The gains used in int conversion.
         compressed (array):  The compressed bytes.
+        n_channels (int):  The number of FLAC channels used (1 or 2).
         local_nbytes (int):  The total number of local compressed bytes.
         global_nbytes (int):  The total global compressed bytes.
         global_process_nbytes (list):  The number of compressed bytes on each process.
@@ -195,8 +197,8 @@ def write_compressed(
     if not have_zarr:
         raise RuntimeError("zarr is not importable, cannot write to a zarr.Group")
 
-    # Writer is currently using version 0
-    from .zarr_load_v0 import zarr_names as znames
+    # Writer is currently using version 1
+    from .zarr_load_v1 import zarr_names as znames
 
     comm = mpi_comm
     if comm is None:
@@ -213,8 +215,9 @@ def write_compressed(
     if rank == 0:
         # This process is participating.  Write the format version string
         # to the top-level group.
-        zgrp.attrs["flacarray_format_version"] = 0
+        zgrp.attrs["flacarray_format_version"] = "1"
         zgrp.attrs["flacarray_software_version"] = flacarray_version
+        zgrp.attrs[znames["flac_channels"]] = f"{n_channels}"
 
         # Create the datasets.  We create the start bytes and auxiliary datasets first
         # and attach any metadata keys to the start bytes dataset (which is always
@@ -335,6 +338,12 @@ def write_array(
     global_shape = global_props["shape"]
     mpi_dist = global_props["dist"]
 
+    # Get the number of channels
+    if arr.dtype == np.dtype(np.int64) or arr.dtype == np.dtype(np.float64):
+        n_channels = 2
+    else:
+        n_channels = 1
+
     # Compress our local piece of the array
     compressed, starts, nbytes, offsets, gains = array_compress(
         arr, level=level, quanta=quanta, precision=precision, use_threads=use_threads
@@ -362,6 +371,7 @@ def write_array(
         offsets,
         gains,
         compressed,
+        n_channels,
         local_nbytes,
         global_nbytes,
         global_proc_bytes,

--- a/src/flacarray/zarr_load_v1.py
+++ b/src/flacarray/zarr_load_v1.py
@@ -25,6 +25,7 @@ zarr_names = {
     "stream_size": "stream_size",
     "stream_offsets": "stream_offsets",
     "stream_gains": "stream_gains",
+    "flac_channels": "flac_channels",
 }
 
 
@@ -134,11 +135,12 @@ def read_compressed(zgrp, keep=None, mpi_comm=None, mpi_dist=None):
         # This process is participating.
         # Double check that we can load this format.
         ver = int(zgrp.attrs["flacarray_format_version"])
-        if ver != 0:
-            msg = f"Version 0 loader called with version {ver} data"
+        if ver != 1:
+            msg = f"Version 1 loader called with version {ver} data"
             raise RuntimeError(msg)
 
         # Get a handle to all the datasets, and extract some metadata.
+        n_channel = int(zgrp.attrs[zarr_names["flac_channels"]])
         dstarts = zgrp[zarr_names["stream_starts"]]
         stream_size = int(dstarts.attrs[zarr_names["stream_size"]])
         global_shape = dstarts.shape + (stream_size,)
@@ -162,6 +164,7 @@ def read_compressed(zgrp, keep=None, mpi_comm=None, mpi_dist=None):
         global_nbytes = mpi_comm.bcast(global_nbytes, root=0)
         stream_gain_dtype = mpi_comm.bcast(stream_gain_dtype, root=0)
         stream_off_dtype = mpi_comm.bcast(stream_off_dtype, root=0)
+        n_channel = mpi_comm.bcast(n_channel, root=0)
 
     # Compute or verify the MPI distribution for the global leading dimension
     mpi_dist = distribute_and_verify(mpi_comm, global_shape[0], mpi_dist=mpi_dist)
@@ -186,14 +189,11 @@ def read_compressed(zgrp, keep=None, mpi_comm=None, mpi_dist=None):
         mpi_dist=mpi_dist,
     )
 
-    # For version 0, the number of channels is always "1", since int64 flac encoding
-    # was not yet supported.  We handle the int64 case in the read_array() function.
-
     return (
         local_shape,
         global_shape,
         compressed,
-        1,
+        n_channel,
         local_starts,
         stream_nbytes,
         stream_offsets,
@@ -277,58 +277,18 @@ def read_array(
         first_samp = stream_slice.start
         last_samp = stream_slice.stop
 
-    # Check for legacy int64 storage format.  Version 0 used 32bit integers plus
-    # an offset to encode a subset of 64bit integers.
-
-    if stream_offsets is not None:
-        if stream_gains is None:
-            # Legacy int64 format.  First decompress the 32bit integers
-            arr = array_decompress(
-                compressed,
-                local_shape[-1],
-                stream_starts,
-                stream_nbytes,
-                stream_offsets=None,
-                stream_gains=None,
-                first_stream_sample=first_samp,
-                last_stream_sample=last_samp,
-                use_threads=use_threads,
-            )
-            # Now add the stream offsets
-            ext_shape = stream_offsets.shape + (1,)
-            arr = arr.astype(np.int64) + stream_offsets.reshape(ext_shape)
-        else:
-            # Either float32 or float64.  Version 0 used the data type of offsets
-            # and gains to determine this, which was fragile.  We decompress the
-            # data as float32 and then promote if needed.
-            arr = array_decompress(
-                compressed,
-                local_shape[-1],
-                stream_starts,
-                stream_nbytes,
-                stream_offsets=stream_offsets,
-                stream_gains=stream_gains,
-                first_stream_sample=first_samp,
-                last_stream_sample=last_samp,
-                use_threads=use_threads,
-            )
-            if stream_gains.dtype == np.dtype(np.float64):
-                # We want float64
-                arr = arr.astype(np.float64)
-    else:
-        # int32
-        arr = array_decompress(
-            compressed,
-            local_shape[-1],
-            stream_starts,
-            stream_nbytes,
-            stream_offsets=None,
-            stream_gains=None,
-            first_stream_sample=first_samp,
-            last_stream_sample=last_samp,
-            use_threads=use_threads,
-        )
-
+    arr = array_decompress(
+        compressed,
+        local_shape[-1],
+        stream_starts,
+        stream_nbytes,
+        stream_offsets=stream_offsets,
+        stream_gains=stream_gains,
+        first_stream_sample=first_samp,
+        last_stream_sample=last_samp,
+        use_threads=use_threads,
+        is_int64=(n_channel == 2),
+    )
     if keep_indices:
         return arr, indices
     else:


### PR DESCRIPTION
- Add native support in the compiled extension for compressing 64bit integers with FLAC.  The high and low 32bits are compressed in separate channels.  On compression (for little-endian systems), the input 64bit integers are simply interpreted as interleaved stereo channels.  On decompression, the separate channels in each frame are extracted to the high / low 32bit portions of the 64bit integers.

- Add 32bit / 64bit wrappers to the bindings, and support for 64bit integers to the mid-level encode / decode functions.

- Changes to the treatment of floating point data.  float32 data is converted to int32 as before, but float64 data is now converted to int64 to gain additional precision.

- Changes to int64 encoding- previously this was restricted to either 32bit range around an offset or forced conversion as floating point data.  Now this data is supported natively.  Remove the int32/int64 conversion routines which are no longer needed.

- Change the HDF5 and Zarr on-disk format (bumping version to "1"). This change was necessary to support storing int64 data without an associated offset.

- Modify and expand unit tests to cover new int64 cases.