### PR TITLE
Use a named logger rather than the default

### DIFF
--- a/src/flacarray/utils.py
+++ b/src/flacarray/utils.py
@@ -18,7 +18,7 @@ from .libflacarray import (
 )
 
 
-log = logging.getLogger()
+log = logging.getLogger("flacarray")
 log.setLevel(logging.INFO)
 env_keys = ["FLACARRAY_LOGLEVEL", "FLACARRAY_LOG_LEVEL"]
 for env_key in env_keys:


### PR DESCRIPTION
The flacarray package should use an independent logger so that the logging level may be set independent of the calling code.  Closes #11 